### PR TITLE
fix flaky FunnelDerivationSpec w.r.t. empty strings

### DIFF
--- a/guava/src/main/scala/magnolify/guava/semiauto/FunnelDerivation.scala
+++ b/guava/src/main/scala/magnolify/guava/semiauto/FunnelDerivation.scala
@@ -71,9 +71,12 @@ trait FunnelImplicits {
     ti: C[T] => Iterable[T]
   ): Funnel[C[T]] =
     funnel { (sink, from) =>
-      // inject a boolean to distinguish `None` and `Some("")`
-      // it might not work for `List("")` vs `List("", "", ...)` though
-      sink.putBoolean(from.nonEmpty)
-      from.foreach(fnl.funnel(_, sink))
+      var i = 0
+      from.foreach { x =>
+        fnl.funnel(x, sink)
+        i += 1
+      }
+      // inject size to distinguish `None`, `Some("")`, and `List("", "", ...)`
+      sink.putInt(i)
     }
 }


### PR DESCRIPTION
This is technically breaking but the only known downstream dependency https://github.com/spotify/scio/pull/2651 hasn't been released yet.