### PR TITLE
micro-optimize cats #71

### DIFF
--- a/cats/src/main/scala/magnolify/cats/semiauto/GroupDerivation.scala
+++ b/cats/src/main/scala/magnolify/cats/semiauto/GroupDerivation.scala
@@ -28,11 +28,22 @@ object GroupDerivation {
   def combine[T](caseClass: CaseClass[Typeclass, T]): Typeclass[T] = {
     val emptyImpl = MonoidMethods.empty(caseClass)
     val combineImpl = SemigroupMethods.combine(caseClass)
+    val combineNImpl = SemigroupMethods.combineN(caseClass)
     val combineAllOptionImpl = SemigroupMethods.combineAllOption(caseClass)
 
     new Group[T] {
       override def empty: T = emptyImpl
       override def combine(x: T, y: T): T = combineImpl(x, y)
+      override def combineN(x: T, n: Int): T =
+        if (n > 0) {
+          combineNImpl(x, n)
+        } else if (n == 0) {
+          emptyImpl
+        } else if (n == Int.MinValue) {
+          combineN(inverse(combine(x, x)), 1073741824)
+        } else {
+          combineNImpl(inverse(x), -n)
+        }
       override def combineAllOption(as: TraversableOnce[T]): Option[T] = combineAllOptionImpl(as)
 
       override def inverse(a: T): T = caseClass.construct { p =>

--- a/cats/src/main/scala/magnolify/cats/semiauto/GroupDerivation.scala
+++ b/cats/src/main/scala/magnolify/cats/semiauto/GroupDerivation.scala
@@ -29,6 +29,7 @@ object GroupDerivation {
     val emptyImpl = MonoidMethods.empty(caseClass)
     val combineImpl = SemigroupMethods.combine(caseClass)
     val combineNImpl = SemigroupMethods.combineN(caseClass)
+    val combineAllImpl = MonoidMethods.combineAll(caseClass)
     val combineAllOptionImpl = SemigroupMethods.combineAllOption(caseClass)
 
     new Group[T] {
@@ -44,6 +45,7 @@ object GroupDerivation {
         } else {
           combineNImpl(inverse(x), -n)
         }
+      override def combineAll(xs: IterableOnce[T]): T = combineAllImpl(xs)
       override def combineAllOption(as: TraversableOnce[T]): Option[T] = combineAllOptionImpl(as)
 
       override def inverse(a: T): T = caseClass.construct { p =>

--- a/cats/src/main/scala/magnolify/cats/semiauto/MonoidDerivation.scala
+++ b/cats/src/main/scala/magnolify/cats/semiauto/MonoidDerivation.scala
@@ -28,11 +28,20 @@ object MonoidDerivation {
   def combine[T](caseClass: CaseClass[Typeclass, T]): Typeclass[T] = {
     val emptyImpl = MonoidMethods.empty(caseClass)
     val combineImpl = SemigroupMethods.combine(caseClass)
+    val combineNImpl = SemigroupMethods.combineN(caseClass)
     val combineAllOptionImpl = SemigroupMethods.combineAllOption(caseClass)
 
     new Monoid[T] {
       override def empty: T = emptyImpl
       override def combine(x: T, y: T): T = combineImpl(x, y)
+      override def combineN(x: T, n: Int): T =
+        if (n < 0) {
+          throw new IllegalArgumentException("Repeated combining for monoids must have n >= 0")
+        } else if (n == 0) {
+          emptyImpl
+        } else {
+          combineNImpl(x, n)
+        }
       override def combineAllOption(as: TraversableOnce[T]): Option[T] = combineAllOptionImpl(as)
     }
   }

--- a/cats/src/main/scala/magnolify/cats/semiauto/MonoidDerivation.scala
+++ b/cats/src/main/scala/magnolify/cats/semiauto/MonoidDerivation.scala
@@ -29,6 +29,7 @@ object MonoidDerivation {
     val emptyImpl = MonoidMethods.empty(caseClass)
     val combineImpl = SemigroupMethods.combine(caseClass)
     val combineNImpl = SemigroupMethods.combineN(caseClass)
+    val combineAllImpl = MonoidMethods.combineAll(caseClass)
     val combineAllOptionImpl = SemigroupMethods.combineAllOption(caseClass)
 
     new Monoid[T] {
@@ -42,6 +43,8 @@ object MonoidDerivation {
         } else {
           combineNImpl(x, n)
         }
+
+      override def combineAll(xs: IterableOnce[T]): T = combineAllImpl(xs)
       override def combineAllOption(as: TraversableOnce[T]): Option[T] = combineAllOptionImpl(as)
     }
   }
@@ -56,4 +59,25 @@ object MonoidDerivation {
 private object MonoidMethods {
   def empty[T, Typeclass[T] <: Monoid[T]](caseClass: CaseClass[Typeclass, T]): T =
     caseClass.construct(_.typeclass.empty)
+
+  def combineAll[T, Typeclass[T] <: Monoid[T]](
+    caseClass: CaseClass[Typeclass, T]
+  ): IterableOnce[T] => T = {
+    val combineImpl = SemigroupMethods.combine(caseClass)
+    val emptyImpl = MonoidMethods.empty(caseClass)
+    xs: IterableOnce[T] =>
+      xs match {
+        case it: Iterable[T] if it.nonEmpty =>
+          // input is re-iterable and non-empty, combineAll on each field
+          val result = Array.fill[Any](caseClass.parameters.length)(null)
+          var i = 0
+          while (i < caseClass.parameters.length) {
+            val p = caseClass.parameters(i)
+            result(i) = p.typeclass.combineAll(it.iterator.map(p.dereference))
+            i += 1
+          }
+          caseClass.rawConstruct(result)
+        case xs => xs.foldLeft(emptyImpl)(combineImpl)
+      }
+  }
 }

--- a/cats/src/main/scala/magnolify/cats/semiauto/SemigroupDerivation.scala
+++ b/cats/src/main/scala/magnolify/cats/semiauto/SemigroupDerivation.scala
@@ -27,10 +27,17 @@ object SemigroupDerivation {
 
   def combine[T](caseClass: CaseClass[Typeclass, T]): Typeclass[T] = {
     val combineImpl = SemigroupMethods.combine(caseClass)
+    val combineNImpl = SemigroupMethods.combineN(caseClass)
     val combineAllOptionImpl = SemigroupMethods.combineAllOption(caseClass)
 
     new Semigroup[T] {
       override def combine(x: T, y: T): T = combineImpl(x, y)
+      override def combineN(x: T, n: Int): T =
+        if (n <= 0) {
+          throw new IllegalArgumentException("Repeated combining for semigroups must have n > 0")
+        } else {
+          combineNImpl(x, n)
+        }
       override def combineAllOption(as: IterableOnce[T]): Option[T] = combineAllOptionImpl(as)
     }
   }
@@ -45,6 +52,9 @@ object SemigroupDerivation {
 private object SemigroupMethods {
   def combine[T, Typeclass[T] <: Semigroup[T]](caseClass: CaseClass[Typeclass, T]): (T, T) => T =
     (x, y) => caseClass.construct(p => p.typeclass.combine(p.dereference(x), p.dereference(y)))
+
+  def combineN[T, Typeclass[T] <: Semigroup[T]](caseClass: CaseClass[Typeclass, T]): (T, Int) => T =
+    (x: T, n: Int) => caseClass.construct(p => p.typeclass.combineN(p.dereference(x), n))
 
   def combineAllOption[T, Typeclass[T] <: Semigroup[T]](
     caseClass: CaseClass[Typeclass, T]

--- a/jmh/src/test/scala/magnolify/jmh/MagnolifyBench.scala
+++ b/jmh/src/test/scala/magnolify/jmh/MagnolifyBench.scala
@@ -56,11 +56,14 @@ class CatsBench {
   private val h = HashDerivation[Nested]
   private val e = EqDerivation[Nested]
   @Benchmark def semigroupCombine: Integers = sg.combine(integers, integers)
+  @Benchmark def semigroupCombineN: Integers = sg.combineN(xs.head, 100)
   @Benchmark def semigroupCombineAllOption: Option[Integers] = sg.combineAllOption(xs)
   @Benchmark def monoidCombine: Integers = mon.combine(integers, integers)
+  @Benchmark def monoidCombineN: Integers = mon.combineN(xs.head, 100)
   @Benchmark def monoidCombineAllOption: Option[Integers] = mon.combineAllOption(xs)
   @Benchmark def monoidEmpty: Integers = mon.empty
   @Benchmark def groupCombine: Integers = grp.combine(integers, integers)
+  @Benchmark def groupCombineN: Integers = grp.combineN(xs.head, 100)
   @Benchmark def groupCombineAllOption: Option[Integers] = grp.combineAllOption(xs)
   @Benchmark def groupEmpty: Integers = grp.empty
   @Benchmark def groupInverse: Integers = grp.inverse(integers)

--- a/jmh/src/test/scala/magnolify/jmh/MagnolifyBench.scala
+++ b/jmh/src/test/scala/magnolify/jmh/MagnolifyBench.scala
@@ -61,10 +61,12 @@ class CatsBench {
   @Benchmark def monoidCombine: Integers = mon.combine(integers, integers)
   @Benchmark def monoidCombineN: Integers = mon.combineN(xs.head, 100)
   @Benchmark def monoidCombineAllOption: Option[Integers] = mon.combineAllOption(xs)
+  @Benchmark def monoidCombineAll: Integers = mon.combineAll(xs)
   @Benchmark def monoidEmpty: Integers = mon.empty
   @Benchmark def groupCombine: Integers = grp.combine(integers, integers)
   @Benchmark def groupCombineN: Integers = grp.combineN(xs.head, 100)
   @Benchmark def groupCombineAllOption: Option[Integers] = grp.combineAllOption(xs)
+  @Benchmark def groupCombineAll: Integers = grp.combineAll(xs)
   @Benchmark def groupEmpty: Integers = grp.empty
   @Benchmark def groupInverse: Integers = grp.inverse(integers)
   @Benchmark def groupRemove: Integers = grp.remove(integers, integers)


### PR DESCRIPTION
Fixes #69 #71

Before:
```
[info] Benchmark                            Mode  Cnt     Score   Error  Units
[info] CatsBench.groupCombineAll            avgt       3578.376          ns/op
[info] CatsBench.groupCombineAllOption      avgt       3223.174          ns/op
[info] CatsBench.groupCombineN              avgt        276.500          ns/op
[info] CatsBench.groupRemove                avgt        139.310          ns/op
[info] CatsBench.monoidCombineAll           avgt       2699.879          ns/op
[info] CatsBench.monoidCombineAllOption     avgt       3902.616          ns/op
[info] CatsBench.monoidCombineN             avgt        269.873          ns/op
[info] CatsBench.semigroupCombineAllOption  avgt       3635.529          ns/op
[info] CatsBench.semigroupCombineN          avgt        276.072          ns/op
```

After:
```
[info] Benchmark                            Mode  Cnt     Score   Error  Units
[info] CatsBench.groupCombineAll            avgt       1547.365          ns/op
[info] CatsBench.groupCombineAllOption      avgt       1560.716          ns/op
[info] CatsBench.groupCombineN              avgt         32.705          ns/op
[info] CatsBench.groupRemove                avgt         26.642          ns/op
[info] CatsBench.monoidCombineAll           avgt       1654.055          ns/op
[info] CatsBench.monoidCombineAllOption     avgt       1551.833          ns/op
[info] CatsBench.monoidCombineN             avgt         32.472          ns/op
[info] CatsBench.semigroupCombineAllOption  avgt       1569.017          ns/op
[info] CatsBench.semigroupCombineN          avgt         37.198          ns/op
```