### PR TITLE
change snake case examples to use underscores

### DIFF
--- a/docs/avro.md
+++ b/docs/avro.md
@@ -55,7 +55,7 @@ import com.google.common.base.CaseFormat
 
 case class LowerCamel(firstName: String, lastName: String)
 
-val toSnakeCase = CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.LOWER_HYPHEN).convert _
+val toSnakeCase = CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.LOWER_UNDERSCORE).convert _
 val avroType = AvroType[LowerCamel](CaseMapper(toSnakeCase))
 avroType.to(LowerCamel("John", "Doe"))
 ```

--- a/docs/bigquery.md
+++ b/docs/bigquery.md
@@ -50,7 +50,7 @@ import com.google.common.base.CaseFormat
 
 case class LowerCamel(firstName: String, lastName: String)
 
-val toSnakeCase = CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.LOWER_HYPHEN).convert _
+val toSnakeCase = CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.LOWER_UNDERSCORE).convert _
 val tableRowType = TableRowType[LowerCamel](CaseMapper(toSnakeCase))
 tableRowType.to(LowerCamel("John", "Doe"))
 ```

--- a/docs/bigtable.md
+++ b/docs/bigtable.md
@@ -31,7 +31,7 @@ import com.google.common.base.CaseFormat
 
 case class LowerCamel(firstName: String, lastName: String)
 
-val toSnakeCase = CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.LOWER_HYPHEN).convert _
+val toSnakeCase = CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.LOWER_UNDERSCORE).convert _
 val bigtableType = BigtableType[LowerCamel](CaseMapper(toSnakeCase))
 bigtableType(LowerCamel("John", "Doe"), "cf")
 ```

--- a/docs/datastore.md
+++ b/docs/datastore.md
@@ -55,7 +55,7 @@ import com.google.common.base.CaseFormat
 
 case class LowerCamel(firstName: String, lastName: String)
 
-val toSnakeCase = CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.LOWER_HYPHEN).convert _
+val toSnakeCase = CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.LOWER_UNDERSCORE).convert _
 val entityType = EntityType[LowerCamel](CaseMapper(toSnakeCase))
 entityType.to(LowerCamel("John", "Doe"))
 ```

--- a/docs/protobuf.md
+++ b/docs/protobuf.md
@@ -52,7 +52,7 @@ import com.google.common.base.CaseFormat
 
 case class LowerCamel(firstName: String, lastName: String)
 
-val toSnakeCase = CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.LOWER_HYPHEN).convert _
+val toSnakeCase = CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.LOWER_UNDERSCORE).convert _
 val protobufType = ProtobufType[LowerCamel, LowerHyphenProto](CaseMapper(toSnakeCase))
 protobufType.to(LowerCamel("John", "Doe"))
 ```

--- a/docs/tensorflow.md
+++ b/docs/tensorflow.md
@@ -35,7 +35,7 @@ import com.google.common.base.CaseFormat
 
 case class LowerCamel(firstName: String, lastName: String)
 
-val toSnakeCase = CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.LOWER_HYPHEN).convert _
+val toSnakeCase = CaseFormat.LOWER_CAMEL.converterTo(CaseFormat.LOWER_UNDERSCORE).convert _
 val exampleType = ExampleType[LowerCamel](CaseMapper(toSnakeCase))
 exampleType.to(LowerCamel("John", "Doe"))
 ```


### PR DESCRIPTION
currently the snake case examples use hyphens which is non-custom for snake case.