### PR TITLE
Support for java.lang.UUID for Bigtable type

### DIFF
--- a/bigtable/src/main/scala/magnolify/bigtable/BigtableType.scala
+++ b/bigtable/src/main/scala/magnolify/bigtable/BigtableType.scala
@@ -190,11 +190,9 @@ object BigtableField {
   implicit val btfFloat = primitive[Float](java.lang.Float.BYTES)(_.getFloat)(_.putFloat(_))
   implicit val btfDouble = primitive[Double](java.lang.Double.BYTES)(_.getDouble)(_.putDouble(_))
   implicit val btfBoolean = from[Byte](_ == 1)(if (_) 1 else 0)
-  implicit val btfUUID = primitive[UUID](16)(bb =>
-    new UUID(bb.getLong, bb.getLong)){
-    (bb, uuid) =>
-      bb.putLong(uuid.getMostSignificantBits)
-      bb.putLong(uuid.getLeastSignificantBits)
+  implicit val btfUUID = primitive[UUID](16)(bb => new UUID(bb.getLong, bb.getLong)) { (bb, uuid) =>
+    bb.putLong(uuid.getMostSignificantBits)
+    bb.putLong(uuid.getLeastSignificantBits)
   }
 
   implicit val btfByteString = new Primitive[ByteString] {

--- a/bigtable/src/main/scala/magnolify/bigtable/BigtableType.scala
+++ b/bigtable/src/main/scala/magnolify/bigtable/BigtableType.scala
@@ -17,6 +17,8 @@
 package magnolify.bigtable
 
 import java.nio.ByteBuffer
+import java.util.UUID
+
 import com.google.bigtable.v2.{Cell, Column, Family, Mutation, Row}
 import com.google.bigtable.v2.Mutation.SetCell
 import com.google.protobuf.ByteString
@@ -24,7 +26,6 @@ import magnolia._
 import magnolify.shared._
 import magnolify.shims.JavaConverters._
 
-import java.util.UUID
 import scala.annotation.implicitNotFound
 import scala.language.experimental.macros
 

--- a/bigtable/src/main/scala/magnolify/bigtable/BigtableType.scala
+++ b/bigtable/src/main/scala/magnolify/bigtable/BigtableType.scala
@@ -17,7 +17,6 @@
 package magnolify.bigtable
 
 import java.nio.ByteBuffer
-
 import com.google.bigtable.v2.{Cell, Column, Family, Mutation, Row}
 import com.google.bigtable.v2.Mutation.SetCell
 import com.google.protobuf.ByteString
@@ -25,6 +24,7 @@ import magnolia._
 import magnolify.shared._
 import magnolify.shims.JavaConverters._
 
+import java.util.UUID
 import scala.annotation.implicitNotFound
 import scala.language.experimental.macros
 
@@ -190,6 +190,12 @@ object BigtableField {
   implicit val btfFloat = primitive[Float](java.lang.Float.BYTES)(_.getFloat)(_.putFloat(_))
   implicit val btfDouble = primitive[Double](java.lang.Double.BYTES)(_.getDouble)(_.putDouble(_))
   implicit val btfBoolean = from[Byte](_ == 1)(if (_) 1 else 0)
+  implicit val btfUUID = primitive[UUID](16)(bb =>
+    new UUID(bb.getLong, bb.getLong)){
+    (bb, uuid) =>
+      bb.putLong(uuid.getMostSignificantBits)
+      bb.putLong(uuid.getLeastSignificantBits)
+  }
 
   implicit val btfByteString = new Primitive[ByteString] {
     override def fromByteString(v: ByteString): ByteString = v

--- a/bigtable/src/test/scala/magnolify/bigtable/test/BigtableTypeSuite.scala
+++ b/bigtable/src/test/scala/magnolify/bigtable/test/BigtableTypeSuite.scala
@@ -18,6 +18,8 @@ package magnolify.bigtable.test
 
 import java.net.URI
 import java.time.Duration
+import java.util.UUID
+
 import cats._
 import com.google.bigtable.v2.Row
 import com.google.protobuf.ByteString
@@ -29,7 +31,6 @@ import magnolify.test.Simple._
 import magnolify.test._
 import org.scalacheck._
 
-import java.util.UUID
 import scala.reflect._
 
 class BigtableTypeSuite extends MagnolifySuite {

--- a/bigtable/src/test/scala/magnolify/bigtable/test/BigtableTypeSuite.scala
+++ b/bigtable/src/test/scala/magnolify/bigtable/test/BigtableTypeSuite.scala
@@ -18,7 +18,6 @@ package magnolify.bigtable.test
 
 import java.net.URI
 import java.time.Duration
-
 import cats._
 import com.google.bigtable.v2.Row
 import com.google.protobuf.ByteString
@@ -30,6 +29,7 @@ import magnolify.test.Simple._
 import magnolify.test._
 import org.scalacheck._
 
+import java.util.UUID
 import scala.reflect._
 
 class BigtableTypeSuite extends MagnolifySuite {
@@ -107,7 +107,7 @@ class BigtableTypeSuite extends MagnolifySuite {
 // Collections are not supported
 case class BigtableNested(b: Boolean, i: Int, s: String, r: Required, o: Option[Required])
 
-case class BigtableTypes(b: Byte, c: Char, s: Short, bs: ByteString, ba: Array[Byte])
+case class BigtableTypes(b: Byte, c: Char, s: Short, bs: ByteString, ba: Array[Byte], uu: UUID)
 
 // Collections are not supported
 case class DefaultInner(i: Int = 1, o: Option[Int] = Some(1))


### PR DESCRIPTION
We have a use case when we need to read/write a case class with `java.lang.UUID` field from/to a BT table. The PR adds support for this type. It is better to store UUID in bytes representation, because it consumes less space than in its string form.