### PR TITLE
Add support for required->optional backward compatibility

### DIFF
--- a/parquet/src/main/scala/magnolify/parquet/ParquetType.scala
+++ b/parquet/src/main/scala/magnolify/parquet/ParquetType.scala
@@ -143,9 +143,11 @@ object ParquetType {
       }
 
       val requestedSchema = Schema.message(parquetType.schema)
-      val pruned = Schema.pruneRequested(context.getFileSchema, requestedSchema)
-      context.getFileSchema.checkContains(pruned)
-      new hadoop.ReadSupport.ReadContext(pruned, java.util.Collections.emptyMap())
+      Schema.checkCompatibility(
+        context.getFileSchema,
+        requestedSchema
+      )
+      new hadoop.ReadSupport.ReadContext(requestedSchema, java.util.Collections.emptyMap())
     }
 
     override def prepareForRead(

--- a/parquet/src/main/scala/magnolify/parquet/Schema.scala
+++ b/parquet/src/main/scala/magnolify/parquet/Schema.scala
@@ -99,8 +99,7 @@ private object Schema {
     }
 
     writer match {
-      case _: GroupType =>
-        val wg = writer.asGroupType()
+      case wg: GroupType =>
         val rg = reader.asGroupType()
         rg.getFields.asScala.foreach { rf =>
           if (wg.containsField(rf.getName)) {

--- a/parquet/src/main/scala/magnolify/parquet/Schema.scala
+++ b/parquet/src/main/scala/magnolify/parquet/Schema.scala
@@ -91,8 +91,10 @@ private object Schema {
         case (r1, r2)                                   => r1 == r2
       }
 
-    if (!isRepetitionBackwardCompatible(writer, reader) ||
-        writer.isPrimitive != reader.isPrimitive) {
+    if (
+      !isRepetitionBackwardCompatible(writer, reader) ||
+      writer.isPrimitive != reader.isPrimitive
+    ) {
       throw new InvalidRecordException(s"$writer found: expected $reader")
     }
 

--- a/parquet/src/test/scala/magnolify/parquet/test/ProjectionPredicateSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/test/ProjectionPredicateSuite.scala
@@ -83,7 +83,8 @@ class ProjectionPredicateSuite extends MagnolifySuite {
     testProjection[ProjectionOrdering2](t => ProjectionOrdering2(t.b2, t.b1, t.i2, t.i1))
     testProjection[ProjectionLogical](t => ProjectionLogical(t.i.toEpochMilli))
     testProjection[ProjectionNestedOptional1](t =>
-      ProjectionNestedOptional1(t.s1, Some(ProjectionInnerOptional1(Some(t.inner.s)))))
+      ProjectionNestedOptional1(t.s1, Some(ProjectionInnerOptional1(Some(t.inner.s))))
+    )
   }
 
   private def testBadProjection[T: ClassTag](implicit rt: ParquetType[T]): Unit =

--- a/parquet/src/test/scala/magnolify/parquet/test/ProjectionPredicateSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/test/ProjectionPredicateSuite.scala
@@ -85,6 +85,9 @@ class ProjectionPredicateSuite extends MagnolifySuite {
     testProjection[ProjectionNestedOptional1](t =>
       ProjectionNestedOptional1(t.s1, Some(ProjectionInnerOptional1(Some(t.inner.s))))
     )
+    testProjection[ProjectionReorderedNested1](t =>
+      ProjectionReorderedNested1(ProjectionReorderedInner1(t.inner.r, t.inner.s), t.s1)
+    )
   }
 
   private def testBadProjection[T: ClassTag](implicit rt: ParquetType[T]): Unit =
@@ -242,3 +245,6 @@ case class ProjectionBadRepetition5(b1: Boolean, r: Option[Int])
 
 case class ProjectionInnerOptional1(s: Option[String])
 case class ProjectionNestedOptional1(s1: String, inner: Option[ProjectionInnerOptional1])
+
+case class ProjectionReorderedInner1(r: List[String], s: String)
+case class ProjectionReorderedNested1(inner: ProjectionReorderedInner1, s1: String)

--- a/parquet/src/test/scala/magnolify/parquet/test/ProjectionPredicateSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/test/ProjectionPredicateSuite.scala
@@ -82,6 +82,8 @@ class ProjectionPredicateSuite extends MagnolifySuite {
     testProjection[ProjectionOrdering1](t => ProjectionOrdering1(t.s1, t.i1, t.b1))
     testProjection[ProjectionOrdering2](t => ProjectionOrdering2(t.b2, t.b1, t.i2, t.i1))
     testProjection[ProjectionLogical](t => ProjectionLogical(t.i.toEpochMilli))
+    testProjection[ProjectionNestedOptional1](t =>
+      ProjectionNestedOptional1(t.s1, Some(ProjectionInnerOptional1(Some(t.inner.s)))))
   }
 
   private def testBadProjection[T: ClassTag](implicit rt: ParquetType[T]): Unit =
@@ -99,7 +101,6 @@ class ProjectionPredicateSuite extends MagnolifySuite {
     testBadProjection[ProjectionBadRepetition3]
     testBadProjection[ProjectionBadRepetition4]
     testBadProjection[ProjectionBadRepetition5]
-    testBadProjection[ProjectionBadRepetition6]
   }
 
   private def testPredicate[T: ClassTag](
@@ -232,9 +233,11 @@ case class ProjectionLogical(i: Long)
 
 case class ProjectionBadName(b1: Boolean, i3: Int)
 case class ProjectionBadType(b1: Boolean, i1: Long)
-case class ProjectionBadRepetition1(b1: Boolean, i1: Option[Int])
-case class ProjectionBadRepetition2(b1: Boolean, i1: List[Int])
-case class ProjectionBadRepetition3(b1: Boolean, o: Int)
-case class ProjectionBadRepetition4(b1: Boolean, o: List[Int])
-case class ProjectionBadRepetition5(b1: Boolean, r: Int)
-case class ProjectionBadRepetition6(b1: Boolean, r: Option[Int])
+case class ProjectionBadRepetition1(b1: Boolean, i1: List[Int])
+case class ProjectionBadRepetition2(b1: Boolean, o: Int)
+case class ProjectionBadRepetition3(b1: Boolean, o: List[Int])
+case class ProjectionBadRepetition4(b1: Boolean, r: Int)
+case class ProjectionBadRepetition5(b1: Boolean, r: Option[Int])
+
+case class ProjectionInnerOptional1(s: Option[String])
+case class ProjectionNestedOptional1(s1: String, inner: Option[ProjectionInnerOptional1])

--- a/parquet/src/test/scala/magnolify/parquet/test/SchemaEvolutionSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/test/SchemaEvolutionSuite.scala
@@ -94,8 +94,7 @@ object SchemaEvolutionSuite {
     locationSchema1proj.setFields(List(country, state).asJava)
 
     val v1proj = Schema.createRecord("UserV1Projection", "", namespace, false)
-    val location1proj = new Schema.Field(
-      "location", locationSchema1proj, "", null)
+    val location1proj = new Schema.Field("location", locationSchema1proj, "", null)
     v1proj.setFields(List(id, name, location1proj).asJava)
 
     (locationSchema1proj, v1proj)
@@ -151,11 +150,11 @@ object SchemaEvolutionSuite {
       .build()
 
   def avroUser1Projection(
-                 id: Long,
-                 name: String,
-                 country: String,
-                 state: Option[String]
-               ): GenericRecord =
+    id: Long,
+    name: String,
+    country: String,
+    state: Option[String]
+  ): GenericRecord =
     new GenericRecordBuilder(user1ProjectionSchema)
       .set("id", id)
       .set("name", name)


### PR DESCRIPTION
The PR adds support for backward compatible change of a field repetition from `required` to `optional`. The case is supported by Avro according to [docs](https://avro.apache.org/docs/current/spec.html): 

```
if reader's is a union, but writer's is not:
The first schema in the reader's union that matches the writer's schema is recursively resolved against it. If none match, an error is signalled.
```

It is also supported by Parquet itself bc `optional` always able to parse `required` bc it is always there. I added a bunch of tests + tested in my own sandbox and didn't find any issues with that.

### Why is this needed ?!

This is needed to support a reader schema that has a field with repetition changed from `required` to `optional`. The change itself is fully supported by Avro and the Parquet itself if backward compatibility only is required. The current implementation doesn't allow this at all because the check is delegated to the [Type.checkContains](https://github.com/apache/parquet-mr/blob/master/parquet-column/src/main/java/org/apache/parquet/schema/Type.java#L352) method.