### PR TITLE
EnumType: get rid of enum instances serialization

### DIFF
--- a/shared/src/main/scala/magnolify/shared/EnumType.scala
+++ b/shared/src/main/scala/magnolify/shared/EnumType.scala
@@ -32,9 +32,10 @@ sealed trait EnumType[T] extends Serializable { self =>
   def to(v: T): String
 
   def map(cm: CaseMapper): EnumType[T] = {
-    val m1 = values.map(v => cm.map(v) -> self.from(v)).toMap
-    val m2 = values.map(v => self.from(v) -> cm.map(v)).toMap
-    EnumType.create(name, namespace, values.map(cm.map), annotations, m1(_), m2(_))
+    val cMap = values.map(v => cm.map(v) -> v).toMap
+    EnumType.create(name, namespace, values.map(cm.map), annotations,
+      v => self.from(cMap(v)),
+      v => cm.map(self.to(v)))
   }
 }
 
@@ -50,13 +51,20 @@ object EnumType {
     f: String => T,
     g: T => String
   ): EnumType[T] = new EnumType[T] {
+
+    @transient private lazy val fMap =
+      _values.map(v => v -> f(v)).toMap
+
+    @transient private lazy val gMap =
+      _values.map(v => f(v) -> v).toMap
+
     override val name: String = _name
     override val namespace: String = _namespace
     override val values: List[String] = _values
     override val valueSet: Set[String] = _values.toSet
     override val annotations: List[Any] = _annotations
-    override def from(v: String): T = f(v)
-    override def to(v: T): String = g(v)
+    override def from(v: String): T = fMap(v)
+    override def to(v: T): String = gMap(v)
   }
 
   //////////////////////////////////////////////////
@@ -129,14 +137,14 @@ object EnumType {
     val ns = sealedTrait.typeName.owner
     val subs = sealedTrait.subtypes.map(_.typeclass)
     val values = subs.flatMap(_.values).toList
-    val m = subs.map(s => s.name -> s.from(s.name)).toMap
+    val m = subs.map(s => s.name -> s.from _).toMap
     val annotations = (sealedTrait.annotations ++ subs.flatMap(_.annotations)).toList
     EnumType.create(
       n,
       ns,
       values,
       annotations,
-      m(_),
+      v => m(v)(v),
       t => sealedTrait.dispatch(t)(_.typeclass.name)
     )
   }

--- a/shared/src/main/scala/magnolify/shared/EnumType.scala
+++ b/shared/src/main/scala/magnolify/shared/EnumType.scala
@@ -33,9 +33,14 @@ sealed trait EnumType[T] extends Serializable { self =>
 
   def map(cm: CaseMapper): EnumType[T] = {
     val cMap = values.map(v => cm.map(v) -> v).toMap
-    EnumType.create(name, namespace, values.map(cm.map), annotations,
+    EnumType.create(
+      name,
+      namespace,
+      values.map(cm.map),
+      annotations,
       v => self.from(cMap(v)),
-      v => cm.map(self.to(v)))
+      v => cm.map(self.to(v))
+    )
   }
 }
 

--- a/test/src/test/scala/magnolify/shared/EnumTypeSuite.scala
+++ b/test/src/test/scala/magnolify/shared/EnumTypeSuite.scala
@@ -56,6 +56,15 @@ class EnumTypeSuite extends MagnolifySuite {
     assertEquals(as, List("Color", "Red"))
   }
 
+  test("ADT No Default Constructor") {
+    val et = ensureSerializable(implicitly[EnumType[ADT.Person]])
+    assertEquals(et.name, "Person")
+    assertEquals(et.namespace, "magnolify.test.ADT")
+    assertEquals(et.values, List("Aldrin", "Neil")) // ADTs are ordered alphabetically
+    assertEquals(et.from("Aldrin"), ADT.Aldrin)
+    assertEquals(et.to(ADT.Neil), "Neil")
+  }
+
   test("JavaEnums CaseMapper") {
     val et = ensureSerializable(EnumType[JavaEnums.Color](CaseMapper(_.toLowerCase)))
     assertEquals(et.values.toSet, JavaEnums.Color.values().map(_.name().toLowerCase).toSet)

--- a/test/src/test/scala/magnolify/test/ADT.scala
+++ b/test/src/test/scala/magnolify/test/ADT.scala
@@ -38,4 +38,12 @@ object ADT {
   case object Red extends Color
   case object Green extends Color
   case object Blue extends Color
+
+  // This is needed to simulate an error with "no valid constructor"
+  // exception on attempt to deserialize a case object implementing an abstract class without
+  // default constructor (observed on Scala 2.12 only).
+  sealed abstract class Person(val entryName: String)
+  case object Aldrin extends Person("Aldrin")
+  case object Neil extends Person("Neil")
+
 }

--- a/test/src/test/scala/magnolify/test/ADT.scala
+++ b/test/src/test/scala/magnolify/test/ADT.scala
@@ -41,7 +41,7 @@ object ADT {
 
   // This is needed to simulate an error with "no valid constructor"
   // exception on attempt to deserialize a case object implementing an abstract class without
-  // default constructor (observed on Scala 2.12 only).
+  // a no-arg constructor (observed on Scala 2.12 only).
   sealed abstract class Person(val entryName: String)
   case object Aldrin extends Person("Aldrin")
   case object Neil extends Person("Neil")


### PR DESCRIPTION
This PR fixes a problem with serializing an instance of `ParqueType` with `EnumType` derived from a `sealed abstract class` without a no-arg constructor e.g.:

```scala
  sealed abstract class Person(val entryName: String)
  case object Aldrin extends Person("Aldrin")
  case object Neil extends Person("Neil")
``` 

The derived `ParquetType` for this enum would fail serialization with the following error:

```
val et = ensureSerializable(implicitly[EnumType[ADT.Person]])

java.io.InvalidClassException: magnolify.test.ADT$Aldrin$; no valid constructor
    at java.io.ObjectStreamClass$ExceptionInfo.newInvalidClassException(ObjectStreamClass.java:169)
    at java.io.ObjectStreamClass.checkDeserialize(ObjectStreamClass.java:874)
    at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2043)
    at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1573)
    at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2287)
    at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2211)
```
The issue could be reproduced only with Scala 2.12 and works fine with 2.13. I think there is a difference in the case object serialization between 2.12 and 2.13.

`ParquetType` is serialized and written to hadoop config to be broadcasted to all workers using HadoopIO. 

The fix handles a rare issue, but it blocks real users to move forward with `parquet-magnolify` and it isn't easy for them to get rid of the constructor with an argument because they don't control that code. Anyways, I think it is better to avoid serialization of enum instances and just initialize them lazily.