### PR TITLE
clarify error message for missing required Parquet fields + add warning for missing optional fields

### DIFF
--- a/parquet/src/main/scala/magnolify/parquet/Schema.scala
+++ b/parquet/src/main/scala/magnolify/parquet/Schema.scala
@@ -112,7 +112,7 @@ private object Schema {
             ) {
               throw new InvalidRecordException(
                 s"Requested field `${rf.getName}` with repetition ${rf.getRepetition} missing from written file schema. " +
-                  s"Available fields are: [${wg.getFields.asScala.map(_.getName).mkString(",")}]"
+                  s"Available fields are: [${wg.getFields.asScala.map(f => s"${f.getName}: ${f.getRepetition}").mkString(",")}]"
               )
             }
           }

--- a/parquet/src/main/scala/magnolify/parquet/Schema.scala
+++ b/parquet/src/main/scala/magnolify/parquet/Schema.scala
@@ -121,7 +121,10 @@ private object Schema {
         val wf = writer.asPrimitiveType()
         val rf = reader.asPrimitiveType()
         if (wf.getPrimitiveTypeName != rf.getPrimitiveTypeName) {
-          throw new InvalidRecordException(s"$rf found: expected $wf")
+          throw new InvalidRecordException(
+            s"Requested ${reader.getName} with primitive type $rf not " +
+              s"found; written file schema had type $wf"
+          )
         }
     }
   }

--- a/parquet/src/main/scala/magnolify/parquet/Schema.scala
+++ b/parquet/src/main/scala/magnolify/parquet/Schema.scala
@@ -111,7 +111,8 @@ private object Schema {
               rf.getLogicalTypeAnnotation != LogicalTypeAnnotation.listType()
             ) {
               throw new InvalidRecordException(
-                s"${rf.getRepetition} field ${rf.getName} missing in file schema"
+                s"Requested field `${rf.getName}` with repetition ${rf.getRepetition} missing from written file schema. " +
+                  s"Available fields are: [${wg.getFields.asScala.map(_.getName).mkString(",")}]"
               )
             }
           }


### PR DESCRIPTION
I ran into this when mistakenly getting the case sensitivity wrong with a typed read :) this error message should hopefully make it easier for people to diagnose issues with their projection case class.

It adds an additional warning for optional fields.

Tested it out in a sample Scio job, with optional & required fields

```bash
# Optional field

WARNING: Requested field `Suit: OPTIONAL` is not present in written file schema and will be evaluated as `Option.empty`. Available fields are: [suit: OPTIONAL]
...
Mar 07, 2022 2:45:34 PM org.apache.beam.sdk.io.hadoop.format.HadoopFormatIO$HadoopInputFormatBoundedSource$HadoopInputFormatReader close
INFO: Closing reader after reading 4 records.
```

```bash
# Required field

[error] org.apache.parquet.io.InvalidRecordException: Requested field `Suit: REQUIRED` is not present in written file schema. Available fields are: [suit: OPTIONAL]
[error] 	at magnolify.parquet.Schema$.$anonfun$checkCompatibility$1(Schema.scala:118)
[error] 	at magnolify.parquet.Schema$.$anonfun$checkCompatibility$1$adapted(Schema.scala:107)
[error] 	at scala.collection.Iterator.foreach(Iterator.scala:943)
[error] 	at scala.collection.Iterator.foreach$(Iterator.scala:943)
[error] 	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
[error] 	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
[error] 	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
[error] 	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
[error] 	at magnolify.parquet.Schema$.checkCompatibility(Schema.scala:107)
[error] 	at magnolify.parquet.ParquetType$ReadSupport.init(ParquetType.scala:148)
...
```