### PR TITLE
(#500) Support FilterPredicate gen for ParquetFields

### DIFF
--- a/parquet/src/main/scala/magnolify/parquet/ParquetType.scala
+++ b/parquet/src/main/scala/magnolify/parquet/ParquetType.scala
@@ -283,6 +283,7 @@ object ParquetField {
         override def write(c: RecordConsumer, v: U)(cm: CaseMapper): Unit = pf.write(c, g(v))(cm)
         override def newConverter: TypeConverter[U] =
           pf.newConverter.asInstanceOf[TypeConverter.Primitive[T]].map(f)
+        override type ParquetT = pf.ParquetT
       }
   }
 
@@ -290,9 +291,10 @@ object ParquetField {
 
   sealed trait Primitive[T] extends ParquetField[T] {
     override protected def isEmpty(v: T): Boolean = false
+    type ParquetT <: Comparable[ParquetT]
   }
 
-  def primitive[T](
+  def primitive[T, UnderlyingT <: Comparable[UnderlyingT]](
     f: RecordConsumer => T => Unit,
     g: => TypeConverter[T],
     ptn: PrimitiveTypeName,
@@ -302,51 +304,62 @@ object ParquetField {
       override def schema(cm: CaseMapper): Type = Schema.primitive(ptn, lta)
       override def write(c: RecordConsumer, v: T)(cm: CaseMapper): Unit = f(c)(v)
       override def newConverter: TypeConverter[T] = g
+      override type ParquetT = UnderlyingT
     }
 
   implicit val pfBoolean =
-    primitive[Boolean](_.addBoolean, TypeConverter.newBoolean, PrimitiveTypeName.BOOLEAN)
+    primitive[Boolean, java.lang.Boolean](
+      _.addBoolean,
+      TypeConverter.newBoolean,
+      PrimitiveTypeName.BOOLEAN
+    )
+
   implicit val pfByte =
-    primitive[Byte](
+    primitive[Byte, Integer](
       c => v => c.addInteger(v),
       TypeConverter.newInt.map(_.toByte),
       PrimitiveTypeName.INT32,
       LogicalTypeAnnotation.intType(8, true)
     )
   implicit val pfShort =
-    primitive[Short](
+    primitive[Short, Integer](
       c => v => c.addInteger(v),
       TypeConverter.newInt.map(_.toShort),
       PrimitiveTypeName.INT32,
       LogicalTypeAnnotation.intType(16, true)
     )
   implicit val pfInt =
-    primitive[Int](
+    primitive[Int, Integer](
       _.addInteger,
       TypeConverter.newInt,
       PrimitiveTypeName.INT32,
       LogicalTypeAnnotation.intType(32, true)
     )
   implicit val pfLong =
-    primitive[Long](
+    primitive[Long, java.lang.Long](
       _.addLong,
       TypeConverter.newLong,
       PrimitiveTypeName.INT64,
       LogicalTypeAnnotation.intType(64, true)
     )
   implicit val pfFloat =
-    primitive[Float](_.addFloat, TypeConverter.newFloat, PrimitiveTypeName.FLOAT)
+    primitive[Float, java.lang.Float](_.addFloat, TypeConverter.newFloat, PrimitiveTypeName.FLOAT)
+
   implicit val pfDouble =
-    primitive[Double](_.addDouble, TypeConverter.newDouble, PrimitiveTypeName.DOUBLE)
+    primitive[Double, java.lang.Double](
+      _.addDouble,
+      TypeConverter.newDouble,
+      PrimitiveTypeName.DOUBLE
+    )
 
   implicit val pfByteArray =
-    primitive[Array[Byte]](
+    primitive[Array[Byte], Binary](
       c => v => c.addBinary(Binary.fromConstantByteArray(v)),
       TypeConverter.newByteArray,
       PrimitiveTypeName.BINARY
     )
   implicit val pfString =
-    primitive[String](
+    primitive[String, Binary](
       c => v => c.addBinary(Binary.fromString(v)),
       TypeConverter.newString,
       PrimitiveTypeName.BINARY,
@@ -448,6 +461,8 @@ object ParquetField {
       override def write(c: RecordConsumer, v: U)(cm: CaseMapper): Unit = pf.write(c, g(v))(cm)
       override def newConverter: TypeConverter[U] =
         pf.newConverter.asInstanceOf[TypeConverter.Primitive[T]].map(f)
+
+      override type ParquetT = pf.ParquetT
     }
   }
 
@@ -490,6 +505,8 @@ object ParquetField {
       override def newConverter: TypeConverter[BigDecimal] = TypeConverter.newByteArray.map { ba =>
         Decimal.fromBytes(ba, precision, scale)
       }
+
+      override type ParquetT = Binary
     }
   }
 
@@ -526,6 +543,8 @@ object ParquetField {
       val l = bb.getLong
       new UUID(h, l)
     }
+
+    override type ParquetT = Binary
   }
 
   implicit val ptDate: Primitive[LocalDate] =

--- a/parquet/src/main/scala/magnolify/parquet/Predicate.scala
+++ b/parquet/src/main/scala/magnolify/parquet/Predicate.scala
@@ -43,7 +43,7 @@ object Predicate {
       case PrimitiveTypeName.FLOAT                           => FilterApi.floatColumn(fieldName)
       case PrimitiveTypeName.DOUBLE                          => FilterApi.doubleColumn(fieldName)
       case PrimitiveTypeName.BOOLEAN                         => FilterApi.booleanColumn(fieldName)
-      case _ => throw new UnsupportedOperationException(s"Unsupported column type $fieldType")
+      case PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY            => FilterApi.binaryColumn(fieldName)
     }
 
     def wrap[T](addFn: (PrimitiveConverter, T) => Unit): T => ScalaFieldT = {
@@ -68,7 +68,8 @@ object Predicate {
         wrap((pc: PC, value: java.lang.Double) => pc.addDouble(value))
       case PrimitiveTypeName.BOOLEAN =>
         wrap((pc: PC, value: java.lang.Boolean) => pc.addBoolean(value))
-      case _ => throw new UnsupportedOperationException(s"Unsupported column type $fieldType")
+      case PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY =>
+        wrap((pc: PC, value: Binary) => pc.addBinary(value))
     }).asInstanceOf[pf.ParquetT => ScalaFieldT]
 
     FilterApi.userDefined[pf.ParquetT, UserDefinedPredicate[pf.ParquetT] with Serializable](

--- a/parquet/src/main/scala/magnolify/parquet/Predicate.scala
+++ b/parquet/src/main/scala/magnolify/parquet/Predicate.scala
@@ -47,7 +47,7 @@ object Predicate {
     }
 
     def wrap[T](addFn: (PrimitiveConverter, T) => Unit): T => ScalaFieldT = {
-      val converter = pf.newConverter
+      lazy val converter = pf.newConverter
       value => {
         addFn(converter.asPrimitiveConverter(), value)
         converter.get

--- a/parquet/src/main/scala/magnolify/parquet/Predicate.scala
+++ b/parquet/src/main/scala/magnolify/parquet/Predicate.scala
@@ -13,7 +13,7 @@ import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 
 object Predicate {
 
-  def onField[RecordT, ScalaFieldT](
+  def onField[ScalaFieldT](
     fieldName: String
   )(filterFn: ScalaFieldT => Boolean)(implicit
     pf: ParquetField.Primitive[ScalaFieldT]

--- a/parquet/src/main/scala/magnolify/parquet/Predicate.scala
+++ b/parquet/src/main/scala/magnolify/parquet/Predicate.scala
@@ -1,0 +1,68 @@
+package magnolify.parquet
+
+import magnolify.shared.CaseMapper
+import org.apache.parquet.filter2.predicate.Operators.Column
+import org.apache.parquet.filter2.predicate.{
+  FilterApi,
+  FilterPredicate,
+  Statistics,
+  UserDefinedPredicate
+}
+import org.apache.parquet.io.api.{Binary, PrimitiveConverter}
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
+
+object Predicate {
+
+  def onField[RecordT, ScalaFieldT](
+    fieldName: String
+  )(filterFn: ScalaFieldT => Boolean)(implicit
+    pf: ParquetField.Primitive[ScalaFieldT]
+  ): FilterPredicate = {
+    val fieldType = pf.schema(CaseMapper.identity).asPrimitiveType().getPrimitiveTypeName
+
+    val column = fieldType match {
+      case PrimitiveTypeName.INT32                           => FilterApi.intColumn(fieldName)
+      case PrimitiveTypeName.INT64 | PrimitiveTypeName.INT96 => FilterApi.longColumn(fieldName)
+      case PrimitiveTypeName.BINARY                          => FilterApi.binaryColumn(fieldName)
+      case PrimitiveTypeName.FLOAT                           => FilterApi.floatColumn(fieldName)
+      case PrimitiveTypeName.DOUBLE                          => FilterApi.doubleColumn(fieldName)
+      case PrimitiveTypeName.BOOLEAN                         => FilterApi.booleanColumn(fieldName)
+      case _ => throw new UnsupportedOperationException(s"Unsupported column type $fieldType")
+    }
+
+    def wrap[T](addFn: (PrimitiveConverter, T) => Unit): T => ScalaFieldT = {
+      val converter = pf.newConverter
+      value => {
+        addFn(converter.asPrimitiveConverter(), value)
+        converter.get
+      }
+    }
+
+    type PC = PrimitiveConverter
+    val converter = (fieldType match {
+      case PrimitiveTypeName.INT32 =>
+        wrap((pc: PC, value: java.lang.Integer) => pc.addInt(value))
+      case PrimitiveTypeName.INT64 | PrimitiveTypeName.INT96 =>
+        wrap((pc: PC, value: java.lang.Long) => pc.addLong(value))
+      case PrimitiveTypeName.BINARY =>
+        wrap((pc: PC, value: Binary) => pc.addBinary(value))
+      case PrimitiveTypeName.FLOAT =>
+        wrap((pc: PC, value: java.lang.Float) => pc.addFloat(value))
+      case PrimitiveTypeName.DOUBLE =>
+        wrap((pc: PC, value: java.lang.Double) => pc.addDouble(value))
+      case PrimitiveTypeName.BOOLEAN =>
+        wrap((pc: PC, value: java.lang.Boolean) => pc.addBoolean(value))
+      case _ => throw new UnsupportedOperationException(s"Unsupported column type $fieldType")
+    }).asInstanceOf[pf.ParquetT => ScalaFieldT]
+
+    FilterApi.userDefined[pf.ParquetT, UserDefinedPredicate[pf.ParquetT] with Serializable](
+      column.asInstanceOf[Column[pf.ParquetT]],
+      new UserDefinedPredicate[pf.ParquetT] with Serializable {
+        override def keep(value: pf.ParquetT): Boolean =
+          filterFn.apply(converter(value))
+        override def canDrop(statistics: Statistics[pf.ParquetT]): Boolean = false
+        override def inverseCanDrop(statistics: Statistics[pf.ParquetT]): Boolean = false
+      }
+    )
+  }
+}

--- a/parquet/src/test/scala/magnolify/parquet/test/PredicateSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/test/PredicateSuite.scala
@@ -32,6 +32,7 @@ import scala.reflect.ClassTag
 
 class PredicateSuite extends MagnolifySuite {
   implicit val baEq: cats.Eq[Array[Byte]] = (x: Array[Byte], y: Array[Byte]) => x.diff(y).isEmpty
+  implicit val pfDecimal = ParquetField.decimal32(9)
   implicit val projectionT = ParquetType[Projection]
   implicit val projectionSubsetT = ParquetType[ProjectionSmall]
 
@@ -48,7 +49,8 @@ class PredicateSuite extends MagnolifySuite {
       i.toLong,
       i.toFloat,
       i.toDouble,
-      Array.fill(i)(i.toByte)
+      Array.fill(i)(i.toByte),
+      BigDecimal(i)
     )
   }
   private val bytes = {
@@ -128,6 +130,11 @@ class PredicateSuite extends MagnolifySuite {
       "customByteArray",
       Predicate.onField[Array[Byte]]("ba")(_.length % 2 == 0),
       records.filter(_.ba.length % 2 == 0)
+    )
+    testPredicate[Projection](
+      "customBigDecimal",
+      Predicate.onField[BigDecimal]("bd")(_.bigDecimal.intValue() % 2 == 0),
+      records.filter(_.bd.bigDecimal.intValue() % 2 == 0)
     )
   }
 
@@ -230,7 +237,8 @@ case class Projection(
   l2: Long,
   f: Float,
   d: Double,
-  ba: Array[Byte]
+  ba: Array[Byte],
+  bd: BigDecimal
 )
 case class ProjectionInner(s: String, o: Option[String])
 case class ProjectionSmall(b1: Boolean, i1: Int, s1: String, inner: ProjectionInner)

--- a/parquet/src/test/scala/magnolify/parquet/test/PredicateSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/test/PredicateSuite.scala
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2022 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package magnolify.parquet.test
+
+import java.{lang => jl}
+import java.time.Instant
+import cats._
+import magnolify.cats.auto._
+import magnolify.parquet._
+import magnolify.parquet.logical.millis._
+import magnolify.test._
+import magnolify.test.Time._
+import org.apache.parquet.filter2.compat.FilterCompat
+import org.apache.parquet.filter2.predicate.{FilterApi, FilterPredicate}
+import org.apache.parquet.io.api.Binary
+
+import scala.reflect.ClassTag
+
+class PredicateSuite extends MagnolifySuite {
+  implicit val baEq: cats.Eq[Array[Byte]] = (x: Array[Byte], y: Array[Byte]) => x.diff(y).isEmpty
+  implicit val projectionT = ParquetType[Projection]
+  implicit val projectionSubsetT = ParquetType[ProjectionSmall]
+
+  private val records = (1 to 100).toList.map { i =>
+    Projection(
+      i % 2 == 0,
+      i,
+      i.toString,
+      (0 to i).toList,
+      if (i % 2 == 0) Some(i) else None,
+      Instant.ofEpochMilli(i),
+      ProjectionInner(i.toString, if (i % 2 == 0) Some(s"o$i") else None),
+      i.toByte,
+      i.toLong,
+      i.toFloat,
+      i.toDouble,
+      Array.fill(i)(i.toByte)
+    )
+  }
+  private val bytes = {
+    val pt = ParquetType[Projection]
+    val out = new TestOutputFile
+    val writer = pt.writeBuilder(out).build()
+    records.foreach(writer.write)
+    writer.close()
+    out.getBytes
+  }
+
+  private def testPredicate[T: ClassTag](
+    name: String,
+    predicate: FilterPredicate,
+    expected: List[T]
+  )(implicit pt: ParquetType[T], eq: Eq[List[T]]): Unit =
+    test(s"Predicate.${className[T]}.$name") {
+      val in = new TestInputFile(bytes)
+      val reader = pt.readBuilder(in).withFilter(FilterCompat.get(predicate)).build()
+      var r = reader.read()
+      val b = List.newBuilder[T]
+      while (r != null) {
+        b += r
+        r = reader.read()
+      }
+      reader.close()
+      eq.eqv(b.result(), expected)
+    }
+
+  {
+    testPredicate[Projection](
+      "customStr",
+      Predicate.onField[String]("s1")(_.toInt % 5 == 0),
+      records.filter(_.s1.toInt % 5 == 0)
+    )
+    testPredicate[Projection](
+      "customBool",
+      Predicate.onField[Boolean]("b1")(identity),
+      records.filter(_.b1)
+    )
+    testPredicate[Projection](
+      "customInt",
+      Predicate.onField[Int]("i1")(_ % 2 == 0),
+      records.filter(_.i1 % 2 == 0)
+    )
+    testPredicate[Projection](
+      "customInstant",
+      Predicate.onField[Instant]("i2")(_.toEpochMilli % 2 == 0),
+      records.filter(_.i2.toEpochMilli % 2 == 0)
+    )
+    testPredicate[Projection](
+      "customNested",
+      Predicate.onField[String]("inner.s")(_.toInt % 5 == 0),
+      records.filter(_.inner.s.toInt % 5 == 0)
+    )
+    testPredicate[Projection](
+      "customOpt",
+      Predicate.onField[Int]("o")(_ % 5 == 0),
+      records.filter(_.o.exists(_ % 5 == 0))
+    )
+    testPredicate[Projection](
+      "customLong",
+      Predicate.onField[Long]("l2")(_ % 2 == 0),
+      records.filter(_.l2 % 2 == 0)
+    )
+    testPredicate[Projection](
+      "customFloat",
+      Predicate.onField[Float]("f")(_ >= 45.5f),
+      records.filter(_.f >= 50.0f)
+    )
+    testPredicate[Projection](
+      "customDouble",
+      Predicate.onField[Double]("d")(_ >= 50.0),
+      records.filter(_.d >= 50.0)
+    )
+    testPredicate[Projection](
+      "customByteArray",
+      Predicate.onField[Array[Byte]]("ba")(_.length % 2 == 0),
+      records.filter(_.ba.length % 2 == 0)
+    )
+  }
+
+  {
+    val colI1 = FilterApi.intColumn("i1")
+    val colI2 = FilterApi.longColumn("i2")
+
+    val pLtEq = FilterApi.ltEq(colI1, jl.Integer.valueOf(10))
+    val eLtEq = records.filter(_.i1 <= 10)
+    testPredicate[Projection]("ltEq", pLtEq, eLtEq)
+
+    val pGtEq = FilterApi.gtEq(colI1, jl.Integer.valueOf(90))
+    val eGtEq = records.filter(_.i1 >= 90)
+    testPredicate[Projection]("gtEq", pGtEq, eGtEq)
+
+    val pOr = FilterApi.or(pLtEq, pGtEq)
+    val eOr = records.filter(t => t.i1 <= 10 || t.i1 >= 90)
+    testPredicate[Projection]("or", pOr, eOr)
+
+    val pAnd = FilterApi.and(
+      FilterApi.gtEq(colI1, jl.Integer.valueOf(40)),
+      FilterApi.ltEq(colI1, jl.Integer.valueOf(60))
+    )
+    val eAnd = records.filter(t => t.i1 >= 40 && t.i1 <= 60)
+    testPredicate[Projection]("and", pAnd, eAnd)
+
+    val pMulti = FilterApi.or(
+      FilterApi.and(
+        FilterApi.gtEq(colI1, jl.Integer.valueOf(45)),
+        FilterApi.ltEq(colI1, jl.Integer.valueOf(55))
+      ),
+      FilterApi.or(
+        FilterApi.eq(colI2, jl.Long.valueOf(115)),
+        FilterApi.eq(colI2, jl.Long.valueOf(125))
+      )
+    )
+    val eMulti = records.filter(t => (t.i1 >= 45 && t.i1 <= 55) || (t.i2 == 115 || t.i2 == 125))
+    testPredicate[Projection]("multi", pMulti, eMulti)
+
+    val pOpt1 = FilterApi.gtEq(FilterApi.intColumn("o"), jl.Integer.valueOf(10))
+    val eOpt1 = records.filter(_.o.exists(_ >= 10))
+    testPredicate[Projection]("opt1", pOpt1, eOpt1)
+
+    // Predicate on missing OPTIONAL field
+    val pOpt2 = FilterApi.eq(FilterApi.intColumn("o"), jl.Integer.valueOf(15))
+    val eOpt2 = records.filter(_.o.contains(15))
+    testPredicate[Projection]("opt2", pOpt2, eOpt2)
+
+    val eInner1 = FilterApi.eq(FilterApi.binaryColumn("inner.s"), Binary.fromString("s50"))
+    val oInner1 = records.filter(_.inner.s == "s50")
+    testPredicate[Projection]("inner1", eInner1, oInner1)
+
+    val eInner2 = FilterApi.eq(FilterApi.binaryColumn("inner.o"), Binary.fromString("o50"))
+    val oInner2 = records.filter(_.inner.o.contains("o50"))
+    testPredicate[Projection]("inner2", eInner2, oInner2)
+
+    val pSubset1 = pLtEq
+    val eSubset1 = eLtEq.map(t => ProjectionSmall(t.b1, t.i1, t.s1, t.inner))
+    testPredicate[ProjectionSmall]("subset1", pSubset1, eSubset1)
+
+    // Predicate on field not in projection
+    val pSubset2 = pMulti
+    val eSubset2 = eMulti.map(t => ProjectionSmall(t.b1, t.i1, t.s1, t.inner))
+    testPredicate[ProjectionSmall]("subset2", pSubset2, eSubset2)
+  }
+
+  private def testBadPredicate(name: String, predicate: FilterPredicate): Unit =
+    test(s"BadPredicate.$name") {
+      val pt = ParquetType[Projection]
+      val in = new TestInputFile(bytes)
+      val reader = pt.readBuilder(in).withFilter(FilterCompat.get(predicate)).build()
+      intercept[IllegalArgumentException](reader.read())
+    }
+
+  {
+    // FIXME: Parquet does not validate non-existent fields
+    // val badName = FilterApi.eq(FilterApi.intColumn("i3"), jl.Integer.valueOf(0))
+    // testBadPredicate[Projection]("name", badName)
+
+    val badType = FilterApi.eq(FilterApi.intColumn("b1"), jl.Integer.valueOf(0))
+    testBadPredicate("type", badType)
+
+    val badRepetition = FilterApi.eq(FilterApi.intColumn("l"), jl.Integer.valueOf(0))
+    testBadPredicate("repetition", badRepetition)
+
+    val badType2 = Predicate.onField[Int]("b1")(_ % 2 == 0)
+    testBadPredicate("type2", badType2)
+  }
+}
+
+case class Projection(
+  b1: Boolean,
+  i1: Int,
+  s1: String,
+  l: List[Int],
+  o: Option[Int],
+  i2: Instant,
+  inner: ProjectionInner,
+  b2: Byte,
+  l2: Long,
+  f: Float,
+  d: Double,
+  ba: Array[Byte]
+)
+case class ProjectionInner(s: String, o: Option[String])
+case class ProjectionSmall(b1: Boolean, i1: Int, s1: String, inner: ProjectionInner)

--- a/parquet/src/test/scala/magnolify/parquet/test/ProjectionPredicateSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/test/ProjectionPredicateSuite.scala
@@ -126,11 +126,25 @@ class ProjectionPredicateSuite extends MagnolifySuite {
     }
 
   {
+    testPredicate[Wide]("customStr",
+      Predicate.onField[Wide, String]("s1")(_.toInt % 5 == 0), records.filter(_.s1.toInt % 5 == 0))
+    testPredicate[Wide]("customBool",
+      Predicate.onField[Wide, Boolean]("b1")(identity), records.filter(_.b1))
+    testPredicate[Wide]("customInt",
+      Predicate.onField[Wide, Int]("i1")(_ % 2 == 0), records.filter(_.i1 % 2 == 0))
+    testPredicate[Wide]("customInstant",
+      Predicate.onField[Wide, Instant]("i")(_.toEpochMilli % 2 == 0), records.filter(_.i.toEpochMilli % 2 == 0))
+    testPredicate[Wide]("customNested",
+      Predicate.onField[Wide, String]("inner.s")(_.contains("5")), records.filter(_.inner.s.contains("5")))
+  }
+
+  {
     val colI1 = FilterApi.intColumn("i1")
     val colI2 = FilterApi.intColumn("i2")
 
     val pLtEq = FilterApi.ltEq(colI1, jl.Integer.valueOf(10))
     val eLtEq = records.filter(_.i1 <= 10)
+
     testPredicate[Wide]("ltEq", pLtEq, eLtEq)
 
     val pGtEq = FilterApi.gtEq(colI1, jl.Integer.valueOf(90))

--- a/parquet/src/test/scala/magnolify/parquet/test/ProjectionPredicateSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/test/ProjectionPredicateSuite.scala
@@ -127,15 +127,15 @@ class ProjectionPredicateSuite extends MagnolifySuite {
 
   {
     testPredicate[Wide]("customStr",
-      Predicate.onField[Wide, String]("s1")(_.toInt % 5 == 0), records.filter(_.s1.toInt % 5 == 0))
+      Predicate.onField[String]("s1")(_.toInt % 5 == 0), records.filter(_.s1.toInt % 5 == 0))
     testPredicate[Wide]("customBool",
-      Predicate.onField[Wide, Boolean]("b1")(identity), records.filter(_.b1))
+      Predicate.onField[Boolean]("b1")(identity), records.filter(_.b1))
     testPredicate[Wide]("customInt",
-      Predicate.onField[Wide, Int]("i1")(_ % 2 == 0), records.filter(_.i1 % 2 == 0))
+      Predicate.onField[Int]("i1")(_ % 2 == 0), records.filter(_.i1 % 2 == 0))
     testPredicate[Wide]("customInstant",
-      Predicate.onField[Wide, Instant]("i")(_.toEpochMilli % 2 == 0), records.filter(_.i.toEpochMilli % 2 == 0))
+      Predicate.onField[Instant]("i")(_.toEpochMilli % 2 == 0), records.filter(_.i.toEpochMilli % 2 == 0))
     testPredicate[Wide]("customNested",
-      Predicate.onField[Wide, String]("inner.s")(_.contains("5")), records.filter(_.inner.s.contains("5")))
+      Predicate.onField[String]("inner.s")(_.contains("5")), records.filter(_.inner.s.contains("5")))
   }
 
   {

--- a/parquet/src/test/scala/magnolify/parquet/test/ProjectionPredicateSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/test/ProjectionPredicateSuite.scala
@@ -126,16 +126,36 @@ class ProjectionPredicateSuite extends MagnolifySuite {
     }
 
   {
-    testPredicate[Wide]("customStr",
-      Predicate.onField[String]("s1")(_.toInt % 5 == 0), records.filter(_.s1.toInt % 5 == 0))
-    testPredicate[Wide]("customBool",
-      Predicate.onField[Boolean]("b1")(identity), records.filter(_.b1))
-    testPredicate[Wide]("customInt",
-      Predicate.onField[Int]("i1")(_ % 2 == 0), records.filter(_.i1 % 2 == 0))
-    testPredicate[Wide]("customInstant",
-      Predicate.onField[Instant]("i")(_.toEpochMilli % 2 == 0), records.filter(_.i.toEpochMilli % 2 == 0))
-    testPredicate[Wide]("customNested",
-      Predicate.onField[String]("inner.s")(_.contains("5")), records.filter(_.inner.s.contains("5")))
+    testPredicate[Wide](
+      "customStr",
+      Predicate.onField[String]("s1")(_.toInt % 5 == 0),
+      records.filter(_.s1.toInt % 5 == 0)
+    )
+    testPredicate[Wide](
+      "customBool",
+      Predicate.onField[Boolean]("b1")(identity),
+      records.filter(_.b1)
+    )
+    testPredicate[Wide](
+      "customInt",
+      Predicate.onField[Int]("i1")(_ % 2 == 0),
+      records.filter(_.i1 % 2 == 0)
+    )
+    testPredicate[Wide](
+      "customInstant",
+      Predicate.onField[Instant]("i")(_.toEpochMilli % 2 == 0),
+      records.filter(_.i.toEpochMilli % 2 == 0)
+    )
+    testPredicate[Wide](
+      "customNested",
+      Predicate.onField[String]("inner.s")(_.contains("5")),
+      records.filter(_.inner.s.contains("5"))
+    )
+    testPredicate[Wide](
+      "customOpt",
+      Predicate.onField[Int]("o")(_ % 5 == 0),
+      records.filter(_.o.exists(_ % 5 == 0))
+    )
   }
 
   {
@@ -144,7 +164,6 @@ class ProjectionPredicateSuite extends MagnolifySuite {
 
     val pLtEq = FilterApi.ltEq(colI1, jl.Integer.valueOf(10))
     val eLtEq = records.filter(_.i1 <= 10)
-
     testPredicate[Wide]("ltEq", pLtEq, eLtEq)
 
     val pGtEq = FilterApi.gtEq(colI1, jl.Integer.valueOf(90))

--- a/parquet/src/test/scala/magnolify/parquet/test/ProjectionSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/test/ProjectionSuite.scala
@@ -25,10 +25,7 @@ import magnolify.parquet._
 import magnolify.parquet.logical.millis._
 import magnolify.test._
 import magnolify.test.Time._
-import org.apache.parquet.filter2.compat.FilterCompat
-import org.apache.parquet.filter2.predicate.{FilterApi, FilterPredicate}
 import org.apache.parquet.io.InvalidRecordException
-import org.apache.parquet.io.api.Binary
 
 import scala.reflect.ClassTag
 


### PR DESCRIPTION
adds support for custom `FilterPredicate` generation for types `T : ParquetField.Primitive`:

```scala
Predicate.onField[Int]("i1")(_ % 2 == 0)
```

I didn't go as far as adding macro support the way @nevillelyh did in [parquet-extra](https://github.com/nevillelyh/parquet-extra/blob/main/parquet-avro/src/main/scala/me/lyh/parquet/avro/Predicate.scala)... this implementation is a little more manual, maybe macro support (i.e `Predicate[RecordT)(_.i1 % 2 == 0)`) can be implemented further down the line. But it leverages the functionality of our Parquet typeclass to do things like convert between underlying Parquet types and the Scala projected type--for example, you can filter directly on `Instant` logical type fields, rather than having to assert on the raw millisecond value.