### PR TITLE
Keep protobuf-java as a "Provided" dep in magnolify-tensorflow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -354,12 +354,14 @@ lazy val tensorflow: Project = project
     Compile / managedSourceDirectories := (Compile / managedSourceDirectories).value
       .filterNot(_.getPath.endsWith("/src_managed/main")),
     libraryDependencies ++= Seq(
-      "org.tensorflow" % "tensorflow-core-api" % tensorflowVersion % Provided,
-      "com.google.protobuf" % "protobuf-java" % protobufVersion % s"${ProtobufConfig.name},${Provided.name}"
+      "org.tensorflow" % "tensorflow-core-api" % tensorflowVersion % Provided
     ),
     // Protobuf plugin adds protobuf-java to Compile scope automatically; we want it to remain Provided
-    libraryDependencies := libraryDependencies.value.filterNot { l =>
-      l.organization == "com.google.protobuf" && l.name == "protobuf-java" && l.configurations.isEmpty
+    libraryDependencies := libraryDependencies.value.map { l =>
+      (l.organization, l.name) match {
+        case ("com.google.protobuf", "protobuf-java") => l.withConfigurations(Some("provided,protobuf"))
+        case _ => l
+      }
     }
   )
   .dependsOn(

--- a/build.sbt
+++ b/build.sbt
@@ -355,8 +355,12 @@ lazy val tensorflow: Project = project
       .filterNot(_.getPath.endsWith("/src_managed/main")),
     libraryDependencies ++= Seq(
       "org.tensorflow" % "tensorflow-core-api" % tensorflowVersion % Provided,
-      "com.google.protobuf" % "protobuf-java" % protobufVersion % ProtobufConfig.name
-    )
+      "com.google.protobuf" % "protobuf-java" % protobufVersion % s"${ProtobufConfig.name},${Provided.name}"
+    ),
+    // Protobuf plugin adds protobuf-java to Compile scope automatically; we want it to remain Provided
+    libraryDependencies := libraryDependencies.value.filterNot { l =>
+      l.organization == "com.google.protobuf" && l.name == "protobuf-java" && l.configurations.isEmpty
+    }
   )
   .dependsOn(
     shared,


### PR DESCRIPTION
I was testing out a snapshot release of Magnolify and noticed that the `tensorflow` module had started bringing in the `protobuf-java` artifact as a compile-time dependency. This is because of the addition of the sbt-protobuf plugin, which [adds protobuf-java to libraryDependencies automatically](https://github.com/sbt/sbt-protobuf#adding-the-plugin-dependency).

Since this is inconsistent with the way Magnolify usually handles these dependencies (keeping them `Provided` as much as possible), I put up this PR fixing the issue by manually updating the scope from to "protobuf,provided".
```sbt
$ sbt tensorflow/libraryDependencies
[info] welcome to sbt 1.6.2 (Oracle Corporation Java 11.0.2)
[info] loading global plugins from /Users/clairemcginty/.sbt/1.0/plugins
[info] loading settings for project magnolify-build from plugins.sbt ...
[info] loading project definition from /Users/clairemcginty/magnolify/project
[info] loading settings for project root from build.sbt ...
[info] resolving key references (14624 settings) ...
[info] set current project to magnolify (in build file:/Users/clairemcginty/magnolify/)
[info] * org.scala-lang:scala-library:2.13.8
[info] * com.google.protobuf:protobuf-java:3.18.0:provided,protobuf
[info] * com.softwaremill.magnolia:magnolia-core:1.0.0-M4
[info] * com.chuusai:shapeless:2.3.9
[info] * org.scala-lang:scala-reflect:2.13.8
[info] * org.tensorflow:tensorflow-core-api:0.3.3:provided
```