### PR TITLE
Streamline with AvroType

### DIFF
--- a/bigquery/src/main/scala/magnolify/bigquery/TableRowType.scala
+++ b/bigquery/src/main/scala/magnolify/bigquery/TableRowType.scala
@@ -18,7 +18,6 @@ package magnolify.bigquery
 
 import java.{util => ju}
 
-import com.google.api.client.json.gson.GsonFactory
 import com.google.api.services.bigquery.model.{TableFieldSchema, TableRow, TableSchema}
 import com.google.common.io.BaseEncoding
 import magnolia1._
@@ -26,6 +25,7 @@ import magnolify.shared.{CaseMapper, Converter}
 import magnolify.shims.FactoryCompat
 import magnolify.shims.JavaConverters._
 
+import scala.collection.concurrent
 import scala.annotation.{implicitNotFound, StaticAnnotation}
 import scala.language.experimental.macros
 
@@ -60,9 +60,13 @@ sealed trait TableRowField[T] extends Serializable {
   type FromT
   type ToT
 
-  protected def schemaString(cm: CaseMapper): String
+  @transient private lazy val schemaCache: concurrent.Map[ju.UUID, TableFieldSchema] =
+    concurrent.TrieMap.empty
+
+  protected def createSchema(cm: CaseMapper): TableFieldSchema
   def fieldSchema(cm: CaseMapper): TableFieldSchema =
-    Schemas.fromJson(schemaString(cm))
+    schemaCache.getOrElseUpdate(cm.uuid, createSchema(cm))
+
   def from(v: FromT)(cm: CaseMapper): T
   def to(v: T)(cm: CaseMapper): ToT
 
@@ -76,30 +80,33 @@ object TableRowField {
   }
 
   sealed trait Generic[T] extends Aux[T, Any, Any]
-  sealed trait Record[T] extends Aux[T, java.util.Map[String, AnyRef], TableRow]
+  sealed trait Record[T] extends Aux[T, ju.Map[String, AnyRef], TableRow]
 
   // ////////////////////////////////////////////////
 
   type Typeclass[T] = TableRowField[T]
 
   def join[T](caseClass: CaseClass[Typeclass, T]): Record[T] = new Record[T] {
-    override protected def schemaString(cm: CaseMapper): String =
-      Schemas.toJson(
-        new TableFieldSchema()
-          .setType("STRUCT")
-          .setMode("REQUIRED")
-          .setDescription(getDescription(caseClass.annotations, caseClass.typeName.full))
-          .setFields(caseClass.parameters.map { p =>
-            p.typeclass
-              .fieldSchema(cm)
-              .setName(cm.map(p.label))
-              .setDescription(
-                getDescription(p.annotations, s"${caseClass.typeName.full}#${p.label}")
-              )
-          }.asJava)
-      )
+    override protected def createSchema(cm: CaseMapper): TableFieldSchema = {
+      // do not use a scala wrapper in the schema, so clone() works
+      val fields = new ju.ArrayList[TableFieldSchema](caseClass.parameters.size)
+      caseClass.parameters.foreach { p =>
+        val f = p.typeclass
+          .fieldSchema(cm)
+          .clone()
+          .setName(cm.map(p.label))
+          .setDescription(getDescription(p.annotations, s"${caseClass.typeName.full}#${p.label}"))
+        fields.add(f)
+      }
 
-    override def from(v: java.util.Map[String, AnyRef])(cm: CaseMapper): T =
+      new TableFieldSchema()
+        .setType("STRUCT")
+        .setMode("REQUIRED")
+        .setDescription(getDescription(caseClass.annotations, caseClass.typeName.full))
+        .setFields(fields)
+    }
+
+    override def from(v: ju.Map[String, AnyRef])(cm: CaseMapper): T =
       caseClass.construct { p =>
         val f = v.get(cm.map(p.label))
         if (f == null && p.default.isDefined) {
@@ -112,10 +119,7 @@ object TableRowField {
     override def to(v: T)(cm: CaseMapper): TableRow =
       caseClass.parameters.foldLeft(new TableRow) { (tr, p) =>
         val f = p.typeclass.to(p.dereference(v))(cm)
-        if (f != null) {
-          tr.put(cm.map(p.label), f)
-        }
-        tr
+        if (f == null) tr else tr.set(cm.map(p.label), f)
       }
 
     private def getDescription(annotations: Seq[Any], name: String): String = {
@@ -142,8 +146,9 @@ object TableRowField {
       new TableRowField[U] {
         override type FromT = trf.FromT
         override type ToT = trf.ToT
-        override protected def schemaString(cm: CaseMapper): String =
-          Schemas.toJson(trf.fieldSchema(cm))
+
+        override protected def createSchema(cm: CaseMapper): TableFieldSchema =
+          trf.fieldSchema(cm)
         override def from(v: FromT)(cm: CaseMapper): U = f(trf.from(v)(cm))
         override def to(v: U)(cm: CaseMapper): ToT = trf.to(g(v))(cm)
       }
@@ -152,9 +157,8 @@ object TableRowField {
   // ////////////////////////////////////////////////
 
   private def at[T](tpe: String)(f: Any => T)(g: T => Any): TableRowField[T] = new Generic[T] {
-    private val _schemaString =
-      Schemas.toJson(new TableFieldSchema().setType(tpe).setMode("REQUIRED"))
-    override protected def schemaString(cm: CaseMapper): String = _schemaString
+    override protected def createSchema(cm: CaseMapper): TableFieldSchema =
+      new TableFieldSchema().setType(tpe).setMode("REQUIRED")
     override def from(v: Any)(cm: CaseMapper): T = f(v)
     override def to(v: T)(cm: CaseMapper): Any = g(v)
   }
@@ -179,8 +183,8 @@ object TableRowField {
 
   implicit def trfOption[T](implicit f: TableRowField[T]): TableRowField[Option[T]] =
     new Aux[Option[T], f.FromT, f.ToT] {
-      override protected def schemaString(cm: CaseMapper): String =
-        Schemas.toJson(f.fieldSchema(cm).setMode("NULLABLE"))
+      override protected def createSchema(cm: CaseMapper): TableFieldSchema =
+        f.fieldSchema(cm).clone().setMode("NULLABLE")
       override def from(v: f.FromT)(cm: CaseMapper): Option[T] =
         if (v == null) None else Some(f.from(v)(cm))
       override def to(v: Option[T])(cm: CaseMapper): f.ToT = v match {
@@ -195,8 +199,8 @@ object TableRowField {
     fc: FactoryCompat[T, C[T]]
   ): TableRowField[C[T]] =
     new Aux[C[T], ju.List[f.FromT], ju.List[f.ToT]] {
-      override protected def schemaString(cm: CaseMapper): String =
-        Schemas.toJson(f.fieldSchema(cm).setMode("REPEATED"))
+      override protected def createSchema(cm: CaseMapper): TableFieldSchema =
+        f.fieldSchema(cm).clone().setMode("REPEATED")
       override def from(v: ju.List[f.FromT])(cm: CaseMapper): C[T] =
         if (v == null) {
           fc.newBuilder.result()
@@ -206,13 +210,6 @@ object TableRowField {
       override def to(v: C[T])(cm: CaseMapper): ju.List[f.ToT] =
         if (v.isEmpty) null else v.iterator.map(f.to(_)(cm)).toList.asJava
     }
-}
-
-private object Schemas {
-  private val jsonFactory = GsonFactory.getDefaultInstance
-  def toJson(schema: TableFieldSchema) = jsonFactory.toString(schema)
-  def fromJson(schemaString: String): TableFieldSchema =
-    jsonFactory.fromString(schemaString, classOf[TableFieldSchema])
 }
 
 private object NumericConverter {

--- a/jmh/src/test/scala/magnolify/jmh/MagnolifyBench.scala
+++ b/jmh/src/test/scala/magnolify/jmh/MagnolifyBench.scala
@@ -85,7 +85,7 @@ class AvroBench {
   private val genericRecord = avroType.to(nested)
   @Benchmark def avroTo: GenericRecord = avroType.to(nested)
   @Benchmark def avroFrom: Nested = avroType.from(genericRecord)
-  @Benchmark def avroSchema: Schema = avroType.schema
+  @Benchmark def avroSchema: Schema = AvroType[Nested].schema
 }
 
 @BenchmarkMode(Array(Mode.AverageTime))
@@ -100,7 +100,7 @@ class TableRowBench {
   private val tableRow = tableRowType.to(nested)
   @Benchmark def tableRowTo: TableRow = tableRowType.to(nested)
   @Benchmark def tableRowFrom: Nested = tableRowType.from(tableRow)
-  @Benchmark def tableRowSchema: TableSchema = tableRowType.schema
+  @Benchmark def tableRowSchema: TableSchema = TableRowType[Nested].schema
 }
 
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/protobuf/src/main/scala/magnolify/protobuf/ProtobufType.scala
+++ b/protobuf/src/main/scala/magnolify/protobuf/ProtobufType.scala
@@ -114,7 +114,9 @@ object ProtobufField {
     override type ToT = To
   }
 
-  sealed trait Record[T] extends Aux[T, Message, Message]
+  sealed trait Record[T] extends Aux[T, Message, Message] {
+    override val default: Option[T] = None
+  }
 
   // ////////////////////////////////////////////////
 
@@ -137,7 +139,7 @@ object ProtobufField {
       )
 
     override val hasOptional: Boolean = caseClass.parameters.exists(_.typeclass.hasOptional)
-    override val default: Option[T] = None
+
     override def checkDefaults(descriptor: Descriptor)(cm: CaseMapper): Unit = {
       val syntax = descriptor.getFile.getSyntax
       val fields = getFields(descriptor)(cm)
@@ -251,7 +253,7 @@ object ProtobufField {
       .asInstanceOf[Array[E]]
       .map(e => e.name() -> e)
       .toMap
-    val default = et.from(map.find(_._2.getNumber == 0).get._1)
+    val default = et.from(map.values.find(_.getNumber == 0).get.name())
     aux2[T, EnumValueDescriptor](default)(e => et.from(e.getName))(e =>
       map(et.to(e)).getValueDescriptor
     )
@@ -264,6 +266,10 @@ object ProtobufField {
         case Some(v) => Some(Some(v))
         case None    => None
       }
+
+      // we must use Option instead of Some because
+      // the underlying field may interpret custom values as null
+      // eg. Unsafe enums are encoded as string and default "" is treated as None
       override def from(v: f.FromT)(cm: CaseMapper): Option[T] =
         if (v == null) None else Option(f.from(v)(cm))
 

--- a/tensorflow/src/main/scala/magnolify/tensorflow/ExampleType.scala
+++ b/tensorflow/src/main/scala/magnolify/tensorflow/ExampleType.scala
@@ -55,12 +55,13 @@ object ExampleType {
 sealed trait ExampleField[T] extends Serializable {
   @transient private lazy val schemaCache: concurrent.Map[ju.UUID, Schema] =
     concurrent.TrieMap.empty
-  def get(f: Features, k: String)(cm: CaseMapper): Value[T]
-  def put(f: Features.Builder, k: String, v: T)(cm: CaseMapper): Features.Builder
 
+  protected def buildSchema(k: String)(cm: CaseMapper): Schema
   def schema(k: String)(cm: CaseMapper): Schema =
     schemaCache.getOrElseUpdate(cm.uuid, buildSchema(k)(cm))
-  protected def buildSchema(k: String)(cm: CaseMapper): Schema
+
+  def get(f: Features, k: String)(cm: CaseMapper): Value[T]
+  def put(f: Features.Builder, k: String, v: T)(cm: CaseMapper): Features.Builder
 }
 
 object ExampleField {

--- a/tensorflow/src/main/scala/magnolify/tensorflow/ExampleType.scala
+++ b/tensorflow/src/main/scala/magnolify/tensorflow/ExampleType.scala
@@ -126,21 +126,16 @@ object ExampleField {
       getDoc(caseClass.annotations, caseClass.typeName.full).foreach(sb.setAnnotation)
 
       caseClass.parameters.foldLeft(sb) { (b, p) =>
-        val s = p.typeclass.buildSchema(key(k, cm.map(p.label)))(cm)
-        val annotatedFs = s.getFeatureList.asScala
-          .map { f =>
-            val maybeAnnotation = if (f.hasAnnotation) {
-              Some(f.getAnnotation)
-            } else {
-              getDoc(p.annotations, s"${caseClass.typeName.full}#${key(k, cm.map(p.label))}")
-            }
-
-            maybeAnnotation match {
-              case Some(a) => f.toBuilder.setAnnotation(a).build()
-              case None    => f
-            }
+        val n = key(k, cm.map(p.label))
+        val s = p.typeclass.schema(k)(cm)
+        val annotatedFs = getDoc(p.annotations, s"${caseClass.typeName.full}#$n")
+          .map { a =>
+            s.getFeatureList.asScala.map { f =>
+              if (f.hasAnnotation) f else f.toBuilder.setAnnotation(a).build()
+            }.asJava
           }
-        b.addAllFeature(annotatedFs.asJava)
+          .getOrElse(s.getFeatureList)
+        b.addAllFeature(annotatedFs)
         b
       }
 

--- a/tensorflow/src/main/scala/magnolify/tensorflow/ExampleType.scala
+++ b/tensorflow/src/main/scala/magnolify/tensorflow/ExampleType.scala
@@ -128,9 +128,9 @@ object ExampleField {
         val s = p.typeclass.schema(cm)
         val fs = s.getFeatureList.asScala.map { f =>
           val fb = f.toBuilder
-          val k = if (f.hasName) key(n, f.getName) else n // primitives do not have name
-          val d = getDoc(p.annotations, s"${caseClass.typeName.full}#$k")
-          fb.setName(k)
+          val fk = if (f.hasName) key(n, f.getName) else n // primitives do not have name
+          val d = getDoc(p.annotations, s"${caseClass.typeName.full}#$fk")
+          fb.setName(fk)
           if (!f.hasAnnotation) d.foreach(fb.setAnnotation)
           fb.build()
         }.asJava


### PR DESCRIPTION
Bring `TableRow` structure similar to `AvroType` in #548 

- No need to fallback to string schemas. Rely on clone (this is a deep copy) to construct schemas
- Use of `set` instead of `put`:

> Sets the given field value (may be null) for the given field name. Any existing value for the field will be overwritten. It may be more slightly more efficient than put(String, Object) because it avoids accessing the field's original value.

jmh perf test are similar between versions.

Caching the schema in `ParquetType`

Fixing schema cache in `ExampleType`
