### PR TITLE
Revert "Set cats and scalacheck as provided"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -187,7 +187,7 @@ lazy val scalacheck: Project = project
     commonSettings,
     moduleName := "magnolify-scalacheck",
     description := "Magnolia add-on for ScalaCheck",
-    libraryDependencies += "org.scalacheck" %% "scalacheck" % scalacheckVersion % Provided
+    libraryDependencies += "org.scalacheck" %% "scalacheck" % scalacheckVersion
   )
   .dependsOn(
     shared,
@@ -201,9 +201,9 @@ lazy val cats: Project = project
     moduleName := "magnolify-cats",
     description := "Magnolia add-on for Cats",
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats-core" % catsVersion % Provided,
-      "com.twitter" %% "algebird-core" % algebirdVersion % Test,
-      "org.typelevel" %% "cats-laws" % catsVersion % Test
+      "org.typelevel" %% "cats-core" % catsVersion,
+      "org.typelevel" %% "cats-laws" % catsVersion % Test,
+      "com.twitter" %% "algebird-core" % algebirdVersion % Test
     )
   )
   .dependsOn(


### PR DESCRIPTION
This reverts commit d053090af3b3e1bb92842e80663b0602cee40c54.

This will break compilation on many consumer if they did not explicitly depend on `cats` or `scalacheck`.
Plan this change for a 'breaking' release