### PR TITLE
Stabilize Protobuf plugin settings for M1 compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -213,9 +213,7 @@ lazy val test: Project = project
       "org.scalameta" %% "munit-scalacheck" % munitVersion % Test,
       "org.typelevel" %% "cats-core" % catsVersion % Test
     ),
-    ProtobufConfig / protobufRunProtoc := (args =>
-      com.github.os72.protocjar.Protoc.runProtoc(args.toArray)
-    )
+    ProtobufConfig / version := protobufVersion
   )
   .dependsOn(shared)
   .enablePlugins(ProtobufPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,10 +9,6 @@ addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 
-libraryDependencies ++= Seq(
-  "com.github.os72" % "protoc-jar" % "3.11.4"
-)
-
 // force usage of scala-xml v2
 // See https://github.com/scoverage/sbt-scoverage/issues/439
 dependencyOverrides += "org.scala-lang.modules" %% "scala-xml" % "2.1.0"


### PR DESCRIPTION
I was unable to build `protobuf / test` on my M1 mac; `protobufGenerate` task failed with `error occurred while compiling protobuf files: Unsupported platform: protoc-3.11.4-osx-aarch_64.exe`.

this PR uses current recommended settings from https://github.com/sbt/sbt-protobuf. Also, we don't need to override `protobufRunProtoc`... in fact, doing so was preventing us from properly setting proto [version](https://github.com/sbt/sbt-protobuf/blob/d8f6d45078f403a0876a37cb0cba8da853b08c3f/src/main/scala/sbtprotobuf/ProtobufPlugin.scala#L67). Now we pick up the latest `com/google/protobuf/protoc` artifact with M1 support 👍 