### PR TITLE
Make schema val @transient in ParquetType

### DIFF
--- a/parquet/src/main/scala/magnolify/parquet/ParquetType.scala
+++ b/parquet/src/main/scala/magnolify/parquet/ParquetType.scala
@@ -86,8 +86,8 @@ object ParquetType {
   )(implicit f: ParquetField[T], pa: ParquetArray): ParquetType[T] = f match {
     case r: ParquetField.Record[_] =>
       new ParquetType[T] {
-        override lazy val schema: MessageType = Schema.message(r.schema(cm))
-        override lazy val avroSchema: AvroSchema = {
+        @transient override lazy val schema: MessageType = Schema.message(r.schema(cm))
+        @transient override lazy val avroSchema: AvroSchema = {
           val s = new AvroSchemaConverter().convert(schema)
           // add doc to avro schema
           SchemaUtil.deepCopy(s, f.typeDoc, f.fieldDocs.get)

--- a/parquet/src/test/scala/magnolify/parquet/AvroParquetSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/AvroParquetSuite.scala
@@ -49,9 +49,14 @@ class AvroParquetSuite extends MagnolifySuite {
     schemaErrors: List[String] = List.empty
   )(implicit
     at: AvroType[T],
-    pt: ParquetType[T],
+    tpe: ParquetType[T],
     eq: Eq[T]
   ): Unit = {
+    // Ensure serializable even after evaluation of `schema` and `avroSchema`
+    val parquetSchema = tpe.schema
+    val avroSchema = tpe.avroSchema
+    val pt = ensureSerializable(tpe)
+
     val name = className[T]
 
     property(s"$name.avro2parquet") {

--- a/parquet/src/test/scala/magnolify/parquet/ParquetTypeSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/ParquetTypeSuite.scala
@@ -44,7 +44,11 @@ class ParquetTypeSuite extends MagnolifySuite {
     t: ParquetType[T],
     eq: Eq[T]
   ): Unit = {
+    // Ensure serializable even after evaluation of `schema`
+    val parquetSchema = t.schema
+    val avroSchema = t.avroSchema
     val tpe = ensureSerializable(t)
+
     property(className[T]) {
       Prop.forAll { t: T =>
         val out = new TestOutputFile

--- a/parquet/src/test/scala/magnolify/parquet/ParquetTypeSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/ParquetTypeSuite.scala
@@ -46,9 +46,6 @@ class ParquetTypeSuite extends MagnolifySuite {
   ): Unit = {
     // Ensure serializable even after evaluation of `schema`
     val parquetSchema = t.schema
-    if (t.avroCompat) {
-      val avroSchema = t.avroSchema
-    }
     val tpe = ensureSerializable(t)
 
     property(className[T]) {

--- a/parquet/src/test/scala/magnolify/parquet/ParquetTypeSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/ParquetTypeSuite.scala
@@ -46,7 +46,9 @@ class ParquetTypeSuite extends MagnolifySuite {
   ): Unit = {
     // Ensure serializable even after evaluation of `schema`
     val parquetSchema = t.schema
-    val avroSchema = t.avroSchema
+    if (t.avroCompat) {
+      val avroSchema = t.avroSchema
+    }
     val tpe = ensureSerializable(t)
 
     property(className[T]) {


### PR DESCRIPTION
There were some issues downstream in Scio because `ParquetType` couldn't be serialized as part of a `PTransform`.

Added `@transient` -- this matches the pattern we use elsewhere in Magnolify like [AvroType](https://github.com/spotify/magnolify/blob/main/avro/src/main/scala/magnolify/avro/AvroType.scala#L50), ExampleType, TableRowType etc :)