### PR TITLE
Added versionScheme and versionPolicyCheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: olafurpg/setup-scala@v10
         with:
           java-version: 1.11.0
-      - run: sbt +headerCheckAll +scalafmtCheckAll scalafmtSbtCheck
+      - run: sbt +versionPolicyCheck +headerCheckAll +scalafmtCheckAll scalafmtSbtCheck
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           java-version: 1.11.0
       - uses: olafurpg/setup-gpg@v3
       - name: Publish ${{ github.ref }}
-        run: sbt ci-release
+        run: sbt versionCheck ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,9 @@ lazy val keepExistingHeader =
         .trim()
   )
 
+ThisBuild / versionScheme := Some("early-semver")
+ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible
+
 ThisBuild / tpolecatDefaultOptionsMode := DevMode
 ThisBuild / tpolecatDevModeOptions ~= { opts =>
   val excludes = Set(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,6 +8,7 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.8.0")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "2.1.0")
 
 // force usage of scala-xml v2
 // See https://github.com/scoverage/sbt-scoverage/issues/439


### PR DESCRIPTION
- Added `versionPolicyCheck` to verify if our change respect the declared `versionPolicyIntention`. I am not sure on 100% the mechanism how it works in CI - it may download the previous version, but it needs to save previous reports to do it
- versionScheme := Some("early-semver") - declares our versioning strategy

https://docs.scala-lang.org/overviews/core/binary-compatibility-for-library-authors.html#versioning-scheme---communicating-compatibility-breakages