### PR TITLE
Configure shared and test modules to cross-build scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.10, 2.12.17]
+        scala: [3.2.1, 2.13.10, 2.12.17]
         java: [corretto@11, corretto@8]
         exclude:
+          - scala: 3.2.1
+            java: corretto@8
           - scala: 2.12.17
             java: corretto@8
     runs-on: ${{ matrix.os }}
@@ -173,6 +175,16 @@ jobs:
             ~/AppData/Local/Coursier/Cache/v1
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Download target directories (3.2.1)
+        uses: actions/download-artifact@v3
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.1
+
+      - name: Inflate target directories (3.2.1)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
 
       - name: Download target directories (2.13.10)
         uses: actions/download-artifact@v3

--- a/build.sbt
+++ b/build.sbt
@@ -100,18 +100,18 @@ ThisBuild / developers := List(
 val scala3 = "3.2.1"
 val scala213 = "2.13.10"
 val scala212 = "2.12.17"
-val defaultScala = scala213
+val scalaDefault = scala213
 
 // github actions
 val java11 = JavaSpec.corretto("11")
 val java8 = JavaSpec.corretto("8")
-val defaultJava = java11
+val javaDefault = java11
 val coverageCond = Seq(
-  s"matrix.scala == '$defaultScala'",
-  s"matrix.java == '${defaultJava.render}'"
+  s"matrix.scala == '$scalaDefault'",
+  s"matrix.java == '${javaDefault.render}'"
 ).mkString(" && ")
 
-ThisBuild / scalaVersion := defaultScala
+ThisBuild / scalaVersion := scalaDefault
 ThisBuild / crossScalaVersions := Seq(scala3, scala213, scala212)
 ThisBuild / githubWorkflowTargetBranches := Seq("main")
 ThisBuild / githubWorkflowJavaVersions := Seq(java11, java8)
@@ -142,8 +142,8 @@ ThisBuild / githubWorkflowAddedJobs ++= Seq(
         name = Some("Build project")
       )
     ),
-    scalas = List(defaultScala),
-    javas = List(defaultJava)
+    scalas = List(scalaDefault),
+    javas = List(javaDefault)
   )
 )
 
@@ -176,14 +176,15 @@ val commonSettings = Seq(
   tlFatalWarningsInCi := false,
   tlJdkRelease := Some(8),
   tlSkipIrrelevantScalas := true,
+  scalacOptions ~= { _.filterNot(_ == "-source:3.0-migration") },
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((3, _)) =>
         Seq(
           // required by magnolia for accessing default values
-          "-Xretain-trees",
+          "-Yretain-trees",
           // tolerate some nested macro expansion
-          "-Ymax-inlines",
+          "-Xmax-inlines",
           "64"
         )
       case Some((2, 13)) =>
@@ -287,6 +288,7 @@ lazy val scalacheck = project
     moduleName := "magnolify-scalacheck",
     description := "Magnolia add-on for ScalaCheck",
     crossScalaVersions := Seq(scala213, scala212),
+    scalaVersion := scalaDefault,
     libraryDependencies += "org.scalacheck" %% "scalacheck" % scalacheckVersion % Provided
   )
 
@@ -302,6 +304,7 @@ lazy val cats = project
     moduleName := "magnolify-cats",
     description := "Magnolia add-on for Cats",
     crossScalaVersions := Seq(scala213, scala212),
+    scalaVersion := scalaDefault,
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-core" % catsVersion % Provided,
       "com.twitter" %% "algebird-core" % algebirdVersion % Test,
@@ -320,7 +323,8 @@ lazy val guava = project
     commonSettings,
     moduleName := "magnolify-guava",
     description := "Magnolia add-on for Guava",
-    crossScalaVersions := Seq(scala213, scala212),
+    crossScalaVersions := Seq(scala212, scala213),
+    scalaVersion := scalaDefault,
     libraryDependencies ++= Seq(
       "com.google.guava" % "guava" % guavaVersion % Provided
     )
@@ -343,6 +347,7 @@ lazy val refined = project
     moduleName := "magnolify-refined",
     description := "Magnolia add-on for Refined",
     crossScalaVersions := Seq(scala213, scala212),
+    scalaVersion := scalaDefault,
     libraryDependencies ++= Seq(
       "com.google.guava" % "guava" % guavaVersion % Provided,
       "eu.timepit" %% "refined" % refinedVersion % Provided,
@@ -368,6 +373,7 @@ lazy val avro = project
     moduleName := "magnolify-avro",
     description := "Magnolia add-on for Apache Avro",
     crossScalaVersions := Seq(scala213, scala212),
+    scalaVersion := scalaDefault,
     libraryDependencies ++= Seq(
       "org.apache.avro" % "avro" % avroVersion % Provided,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion % Test
@@ -387,6 +393,7 @@ lazy val bigquery = project
     moduleName := "magnolify-bigquery",
     description := "Magnolia add-on for Google Cloud BigQuery",
     crossScalaVersions := Seq(scala213, scala212),
+    scalaVersion := scalaDefault,
     libraryDependencies ++= Seq(
       "com.google.apis" % "google-api-services-bigquery" % bigqueryVersion % Provided,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion % Test
@@ -406,6 +413,7 @@ lazy val bigtable: Project = project
     moduleName := "magnolify-bigtable",
     description := "Magnolia add-on for Google Cloud Bigtable",
     crossScalaVersions := Seq(scala213, scala212),
+    scalaVersion := scalaDefault,
     libraryDependencies ++= Seq(
       "com.google.api.grpc" % "proto-google-cloud-bigtable-v2" % bigtableVersion % Provided
     )
@@ -424,6 +432,7 @@ lazy val datastore = project
     moduleName := "magnolify-datastore",
     description := "Magnolia add-on for Google Cloud Datastore",
     crossScalaVersions := Seq(scala213, scala212),
+    scalaVersion := scalaDefault,
     libraryDependencies ++= Seq(
       "com.google.cloud.datastore" % "datastore-v1-proto-client" % datastoreVersion % Provided
     )
@@ -443,6 +452,7 @@ lazy val parquet = project
     moduleName := "magnolify-parquet",
     description := "Magnolia add-on for Apache Parquet",
     crossScalaVersions := Seq(scala213, scala212),
+    scalaVersion := scalaDefault,
     libraryDependencies ++= Seq(
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion % Provided,
       "org.apache.parquet" % "parquet-avro" % parquetVersion % Provided,
@@ -468,6 +478,7 @@ lazy val protobuf = project
     moduleName := "magnolify-protobuf",
     description := "Magnolia add-on for Google Protocol Buffer",
     crossScalaVersions := Seq(scala213, scala212),
+    scalaVersion := scalaDefault,
   )
 
 val unpackMetadata = taskKey[Seq[File]]("Unpack tensorflow metadata proto files.")
@@ -486,6 +497,7 @@ lazy val tensorflow = project
     moduleName := "magnolify-tensorflow",
     description := "Magnolia add-on for TensorFlow",
     crossScalaVersions := Seq(scala213, scala212),
+    scalaVersion := scalaDefault,
     libraryDependencies ++= Seq(
       "com.google.protobuf" % "protobuf-java" % protobufVersion % ProtobufConfig,
       "org.tensorflow" % "tensorflow-core-api" % tensorflowVersion % Provided
@@ -521,6 +533,7 @@ lazy val neo4j = project
     moduleName := "magnolify-neo4j",
     description := "Magnolia add-on for Neo4j",
     crossScalaVersions := Seq(scala213, scala212),
+    scalaVersion := scalaDefault,
     libraryDependencies ++= Seq(
       "org.neo4j.driver" % "neo4j-java-driver" % neo4jDriverVersion % Provided
     )
@@ -540,6 +553,7 @@ lazy val tools = project
     moduleName := "magnolify-tools",
     description := "Magnolia add-on for code generation",
     crossScalaVersions := Seq(scala213, scala212),
+    scalaVersion := scalaDefault,
     libraryDependencies ++= Seq(
       "com.google.apis" % "google-api-services-bigquery" % bigqueryVersion,
       "org.apache.avro" % "avro" % avroVersion % Provided,
@@ -565,7 +579,8 @@ lazy val jmh: Project = project
   )
   .settings(
     commonSettings,
-    crossScalaVersions := Seq(scala213),
+    crossScalaVersions := Seq(scalaDefault),
+    scalaVersion := scalaDefault,
     Jmh / classDirectory := (Test / classDirectory).value,
     Jmh / dependencyClasspath := (Test / dependencyClasspath).value,
     // rewire tasks, so that 'jmh:run' automatically invokes 'jmh:compile'

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@
 import sbtprotoc.ProtocPlugin.ProtobufConfig
 
 val magnoliaScala2Version = "1.1.3"
-val magnoliaScala3Version = "1.1.4"
+val magnoliaScala3Version = "1.2.6"
 
 val algebirdVersion = "0.13.9"
 val avroVersion = Option(sys.props("avro.version")).getOrElse("1.11.0")
@@ -40,7 +40,7 @@ val tensorflowMetadataVersion = "1.10.0"
 val tensorflowVersion = "0.4.2"
 
 // project
-ThisBuild / tlBaseVersion := "0.6"
+ThisBuild / tlBaseVersion := "0.7"
 ThisBuild / organization := "com.spotify"
 ThisBuild / organizationName := "Spotify AB"
 ThisBuild / startYear := Some(2016)
@@ -112,7 +112,7 @@ val coverageCond = Seq(
 ).mkString(" && ")
 
 ThisBuild / scalaVersion := defaultScala
-ThisBuild / crossScalaVersions := Seq(scala213, scala212)
+ThisBuild / crossScalaVersions := Seq(scala3, scala213, scala212)
 ThisBuild / githubWorkflowTargetBranches := Seq("main")
 ThisBuild / githubWorkflowJavaVersions := Seq(java11, java8)
 ThisBuild / githubWorkflowBuild := Seq(
@@ -286,6 +286,7 @@ lazy val scalacheck = project
     commonSettings,
     moduleName := "magnolify-scalacheck",
     description := "Magnolia add-on for ScalaCheck",
+    crossScalaVersions := Seq(scala213, scala212),
     libraryDependencies += "org.scalacheck" %% "scalacheck" % scalacheckVersion % Provided
   )
 
@@ -300,6 +301,7 @@ lazy val cats = project
     commonSettings,
     moduleName := "magnolify-cats",
     description := "Magnolia add-on for Cats",
+    crossScalaVersions := Seq(scala213, scala212),
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-core" % catsVersion % Provided,
       "com.twitter" %% "algebird-core" % algebirdVersion % Test,
@@ -318,6 +320,7 @@ lazy val guava = project
     commonSettings,
     moduleName := "magnolify-guava",
     description := "Magnolia add-on for Guava",
+    crossScalaVersions := Seq(scala213, scala212),
     libraryDependencies ++= Seq(
       "com.google.guava" % "guava" % guavaVersion % Provided
     )
@@ -339,6 +342,7 @@ lazy val refined = project
     commonSettings,
     moduleName := "magnolify-refined",
     description := "Magnolia add-on for Refined",
+    crossScalaVersions := Seq(scala213, scala212),
     libraryDependencies ++= Seq(
       "com.google.guava" % "guava" % guavaVersion % Provided,
       "eu.timepit" %% "refined" % refinedVersion % Provided,
@@ -363,6 +367,7 @@ lazy val avro = project
     commonSettings,
     moduleName := "magnolify-avro",
     description := "Magnolia add-on for Apache Avro",
+    crossScalaVersions := Seq(scala213, scala212),
     libraryDependencies ++= Seq(
       "org.apache.avro" % "avro" % avroVersion % Provided,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion % Test
@@ -381,6 +386,7 @@ lazy val bigquery = project
     commonSettings,
     moduleName := "magnolify-bigquery",
     description := "Magnolia add-on for Google Cloud BigQuery",
+    crossScalaVersions := Seq(scala213, scala212),
     libraryDependencies ++= Seq(
       "com.google.apis" % "google-api-services-bigquery" % bigqueryVersion % Provided,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion % Test
@@ -399,6 +405,7 @@ lazy val bigtable: Project = project
     commonSettings,
     moduleName := "magnolify-bigtable",
     description := "Magnolia add-on for Google Cloud Bigtable",
+    crossScalaVersions := Seq(scala213, scala212),
     libraryDependencies ++= Seq(
       "com.google.api.grpc" % "proto-google-cloud-bigtable-v2" % bigtableVersion % Provided
     )
@@ -416,6 +423,7 @@ lazy val datastore = project
     commonSettings,
     moduleName := "magnolify-datastore",
     description := "Magnolia add-on for Google Cloud Datastore",
+    crossScalaVersions := Seq(scala213, scala212),
     libraryDependencies ++= Seq(
       "com.google.cloud.datastore" % "datastore-v1-proto-client" % datastoreVersion % Provided
     )
@@ -434,6 +442,7 @@ lazy val parquet = project
     commonSettings,
     moduleName := "magnolify-parquet",
     description := "Magnolia add-on for Apache Parquet",
+    crossScalaVersions := Seq(scala213, scala212),
     libraryDependencies ++= Seq(
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion % Provided,
       "org.apache.parquet" % "parquet-avro" % parquetVersion % Provided,
@@ -457,7 +466,8 @@ lazy val protobuf = project
     commonSettings,
     protobufSettings,
     moduleName := "magnolify-protobuf",
-    description := "Magnolia add-on for Google Protocol Buffer"
+    description := "Magnolia add-on for Google Protocol Buffer",
+    crossScalaVersions := Seq(scala213, scala212),
   )
 
 val unpackMetadata = taskKey[Seq[File]]("Unpack tensorflow metadata proto files.")
@@ -475,6 +485,7 @@ lazy val tensorflow = project
     protobufSettings,
     moduleName := "magnolify-tensorflow",
     description := "Magnolia add-on for TensorFlow",
+    crossScalaVersions := Seq(scala213, scala212),
     libraryDependencies ++= Seq(
       "com.google.protobuf" % "protobuf-java" % protobufVersion % ProtobufConfig,
       "org.tensorflow" % "tensorflow-core-api" % tensorflowVersion % Provided
@@ -509,6 +520,7 @@ lazy val neo4j = project
     commonSettings,
     moduleName := "magnolify-neo4j",
     description := "Magnolia add-on for Neo4j",
+    crossScalaVersions := Seq(scala213, scala212),
     libraryDependencies ++= Seq(
       "org.neo4j.driver" % "neo4j-java-driver" % neo4jDriverVersion % Provided
     )
@@ -527,6 +539,7 @@ lazy val tools = project
     commonSettings,
     moduleName := "magnolify-tools",
     description := "Magnolia add-on for code generation",
+    crossScalaVersions := Seq(scala213, scala212),
     libraryDependencies ++= Seq(
       "com.google.apis" % "google-api-services-bigquery" % bigqueryVersion,
       "org.apache.avro" % "avro" % avroVersion % Provided,
@@ -552,6 +565,7 @@ lazy val jmh: Project = project
   )
   .settings(
     commonSettings,
+    crossScalaVersions := Seq(scala213),
     Jmh / classDirectory := (Test / classDirectory).value,
     Jmh / dependencyClasspath := (Test / dependencyClasspath).value,
     // rewire tasks, so that 'jmh:run' automatically invokes 'jmh:compile'

--- a/shared/src/main/scala-2/magnolify/shared/AnnotationTypeMacros.scala
+++ b/shared/src/main/scala-2/magnolify/shared/AnnotationTypeMacros.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package magnolify.shared
+
+import scala.reflect.macros.whitebox
+
+object AnnotationTypeMacros {
+  def annotationTypeMacro[T: c.WeakTypeTag](c: whitebox.Context): c.Tree = {
+    import c.universe._
+    val wtt = weakTypeTag[T]
+    val pre = wtt.tpe.asInstanceOf[TypeRef].pre
+
+    // Scala 2.12 & 2.13 macros seem to handle annotations differently
+    // Scala annotation works in both but Java annotations only works in 2.13
+    val saType = typeOf[scala.annotation.StaticAnnotation]
+    val jaType = typeOf[java.lang.annotation.Annotation]
+    // Annotation for Scala enumerations are on the outer object
+    val annotated = if (pre <:< typeOf[scala.Enumeration]) pre else wtt.tpe
+    val trees = annotated.typeSymbol.annotations.collect {
+      case t if t.tree.tpe <:< saType && !(t.tree.tpe <:< jaType) =>
+        // FIXME `t.tree` should work but somehow crashes the compiler
+        val q"new $n(..$args)" = t.tree
+        q"new $n(..$args)"
+    }
+
+    // Get Java annotations via reflection
+    val j = q"classOf[${annotated.typeSymbol.asClass}].getAnnotations.toList"
+    val annotations = q"_root_.scala.List(..$trees) ++ $j"
+
+    q"_root_.magnolify.shared.AnnotationType[$wtt]($annotations)"
+  }
+}
+
+trait AnnotationTypeCompanionMacros {
+  implicit def gen[T]: AnnotationType[T] = macro AnnotationTypeMacros.annotationTypeMacro[T]
+}

--- a/shared/src/main/scala-2/magnolify/shared/EnumTypeDerivation.scala
+++ b/shared/src/main/scala-2/magnolify/shared/EnumTypeDerivation.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package magnolify.shared
+
+import magnolia1.{CaseClass, SealedTrait}
+
+trait EnumTypeDerivation {
+  type Typeclass[T] = EnumType[T]
+
+  def join[T](caseClass: CaseClass[Typeclass, T]): Typeclass[T] = {
+    require(caseClass.isObject, s"Cannot derive EnumType[T] for case class ${caseClass.typeName}")
+    val n = caseClass.typeName.short
+    val ns = caseClass.typeName.owner
+    EnumType.create(
+      n,
+      ns,
+      List(n),
+      caseClass.annotations.toList,
+      _ => caseClass.rawConstruct(Nil)
+    )
+  }
+
+  def split[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] = {
+    val n = sealedTrait.typeName.short
+    val ns = sealedTrait.typeName.owner
+    val subs = sealedTrait.subtypes.map(_.typeclass)
+    val values = subs.flatMap(_.values).toList
+    val annotations = (sealedTrait.annotations ++ subs.flatMap(_.annotations)).toList
+    EnumType.create(
+      n,
+      ns,
+      values,
+      annotations,
+      // it is ok to use the inefficient find here because it will be called only once
+      // and cached inside an instance of EnumType
+      v => subs.find(_.name == v).get.from(v)
+    )
+  }
+}

--- a/shared/src/main/scala-2/magnolify/shared/EnumTypeMacros.scala
+++ b/shared/src/main/scala-2/magnolify/shared/EnumTypeMacros.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package magnolify.shared
+
+import magnolia1.Magnolia
+import scala.reflect.macros.whitebox
+
+object EnumTypeMacros {
+  def scalaEnumTypeMacro[T: c.WeakTypeTag](
+    c: whitebox.Context
+  )(annotations: c.Expr[AnnotationType[T]]): c.Tree = {
+    import c.universe._
+    val wtt = weakTypeTag[T]
+    val ref = wtt.tpe.asInstanceOf[TypeRef]
+    val name = ref.pre.typeSymbol.asClass.fullName // find the enum type from the value type
+    val idx = name.lastIndexOf('.')
+    val n = name.drop(idx + 1)
+    val ns = name.take(idx)
+    val list = q"${ref.pre.termSymbol}.values.iterator.map(_.toString).toList"
+    val map = q"${ref.pre.termSymbol}.values.iterator.map(x => x.toString -> x).toMap"
+    q"""
+        _root_.magnolify.shared.EnumType.create[$wtt](
+          $n, $ns, $list, $annotations.annotations, $map.apply(_)
+        )
+     """
+  }
+}
+
+trait EnumTypeCompanionMacros extends EnumTypeCompanionLowPrioMacros {
+  implicit def scalaEnumType[T <: Enumeration#Value: AnnotationType]: EnumType[T] =
+    macro EnumTypeMacros.scalaEnumTypeMacro[T]
+}
+
+trait EnumTypeCompanionLowPrioMacros extends EnumTypeDerivation {
+  implicit def gen[T]: EnumType[T] = macro Magnolia.gen[T]
+}

--- a/shared/src/main/scala-3/magnolify/shared/AnnotationTypeMacros.scala
+++ b/shared/src/main/scala-3/magnolify/shared/AnnotationTypeMacros.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package magnolify.shared
+
+import scala.quoted.*
+import scala.reflect.ClassTag
+
+object AnnotationTypeMacros:
+  private def getClassTag[T](using Type[T], Quotes): Expr[ClassTag[T]] =
+    import quotes.reflect._
+    Expr.summon[ClassTag[T]] match
+      case Some(ct) =>
+        ct
+      case None =>
+        report.error(
+          s"Unable to find a ClassTag for type ${Type.show[T]}",
+          Position.ofMacroExpansion
+        )
+        throw new Exception("Error when applying macro")
+
+  def annotationTypeMacro[T: Type](using quotes: Quotes): Expr[AnnotationType[T]] =
+    import quotes.reflect.*
+    val annotated = Type.of[T] match
+      case '[Enumeration#Value] =>
+        // Annotation for Scala enumerations are on the outer object
+        val TypeRef(pre, _) = TypeRepr.of[T]: @unchecked
+        pre
+      case _ =>
+        TypeRepr.of[T]
+
+    // only collect scala annotations
+    val sAnnotations =
+      Expr.ofList[Any](annotated.typeSymbol.annotations.map(_.asExprOf[Any]).filter {
+        case '{ $x: java.lang.annotation.Annotation }   => false
+        case '{ $x: scala.annotation.StaticAnnotation } => true
+        case _                                          => false
+      })
+    val jAnnotations = annotated.asType match
+      case '[t] => '{ ${ getClassTag[t] }.runtimeClass.getAnnotations.toList }
+    val annotations = '{ $sAnnotations ++ $jAnnotations }
+    '{ AnnotationType[T]($annotations) }
+
+trait AnnotationTypeCompanionMacros:
+  inline given gen[T]: AnnotationType[T] = ${ AnnotationTypeMacros.annotationTypeMacro[T] }

--- a/shared/src/main/scala-3/magnolify/shared/EnumTypeDerivation.scala
+++ b/shared/src/main/scala-3/magnolify/shared/EnumTypeDerivation.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package magnolify.shared
+
+import magnolia1.{CaseClass, Derivation, SealedTrait}
+
+import scala.deriving.Mirror
+
+trait EnumTypeDerivation extends Derivation[EnumType]:
+
+  def join[T](caseClass: CaseClass[EnumType, T]): EnumType[T] =
+    require(caseClass.isObject, s"Cannot derive EnumType[T] for case class ${caseClass.typeInfo}")
+    val n = caseClass.typeInfo.short
+    val ns = caseClass.typeInfo.owner
+    EnumType.create(
+      n,
+      ns,
+      List(n),
+      caseClass.annotations.toList,
+      _ => caseClass.rawConstruct(Nil)
+    )
+  end join
+
+  def split[T](sealedTrait: SealedTrait[EnumType, T]): EnumType[T] =
+    val n = sealedTrait.typeInfo.short
+    val ns = sealedTrait.typeInfo.owner
+    val subs = sealedTrait.subtypes.map(_.typeclass)
+    val values = subs.flatMap(_.values).toList
+    val annotations = (sealedTrait.annotations ++ subs.flatMap(_.annotations)).toList
+    EnumType.create(
+      n,
+      ns,
+      values,
+      annotations,
+      // it is ok to use the inefficient find here because it will be called only once
+      // and cached inside an instance of EnumType
+      v => subs.find(_.name == v).get.from(v)
+    )
+  end split

--- a/shared/src/main/scala-3/magnolify/shared/EnumTypeMacros.scala
+++ b/shared/src/main/scala-3/magnolify/shared/EnumTypeMacros.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package magnolify.shared
+
+import scala.quoted.*
+import scala.deriving.Mirror
+
+object EnumTypeMacros:
+  def scalaEnumTypeMacro[T: Type](annotations: Expr[AnnotationType[T]])(using
+    quotes: Quotes
+  ): Expr[EnumType[T]] =
+    import quotes.reflect.*
+    val TypeRef(ref, _) = TypeRepr.of[T]: @unchecked // find the enum type from the value type
+    val e = Ref(ref.termSymbol).asExprOf[Enumeration]
+    val name = ref.show
+    val idx = name.lastIndexOf('.')
+    val n = Expr(name.drop(idx + 1))
+    val ns = Expr(name.take(idx))
+    val vs = '{ $e.values.map(_.toString).toList }
+    val as = '{ $annotations.annotations }
+    val map = '{ $e.values.iterator.map(x => x.toString -> x.asInstanceOf[T]).toMap.apply(_) }
+    '{ EnumType.create[T]($n, $ns, $vs, $as, $map) }
+
+trait EnumTypeCompanionMacros extends EnumTypeCompanionMacros0
+
+trait EnumTypeCompanionMacros0 extends EnumTypeCompanionMacros1:
+  inline given scalaEnumType[T <: Enumeration#Value](using
+    annotations: AnnotationType[T]
+  ): EnumType[T] =
+    ${ EnumTypeMacros.scalaEnumTypeMacro[T]('annotations) }
+
+trait EnumTypeCompanionMacros1 extends EnumTypeDerivation:
+  inline given gen[T](using Mirror.Of[T]): EnumType[T] = derivedMirror[T]

--- a/shared/src/main/scala-3/magnolify/shims/package.scala
+++ b/shared/src/main/scala-3/magnolify/shims/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Spotify AB
+ * Copyright 2023 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,13 @@
  * limitations under the License.
  */
 
-package magnolify.shared
+package magnolify
 
-import magnolify.test.ADT
-import magnolify.test.JavaEnums
-import magnolify.test.Simple.ScalaEnums
-object TestEnumType {
+import scala.util.hashing.MurmurHash3
+import scala.collection.compat.Factory
 
-  implicit val etJava: EnumType[JavaEnums.Color] =
-    EnumType.javaEnumType[JavaEnums.Color]
-  implicit val etScala: EnumType[ScalaEnums.Color.Type] =
-    EnumType.scalaEnumType[ScalaEnums.Color.Type]
-  implicit val etAdt: EnumType[ADT.Color] =
-    EnumType.gen[ADT.Color]
+package object shims:
+  type FactoryCompat[-A, +C] = Factory[A, C]
 
-}
+  object MurmurHash3Compat:
+    def seed(data: Int): Int = MurmurHash3.mix(MurmurHash3.productSeed, data)

--- a/shared/src/main/scala/magnolify/shared/AnnotationType.scala
+++ b/shared/src/main/scala/magnolify/shared/AnnotationType.scala
@@ -16,35 +16,8 @@
 
 package magnolify.shared
 
-import scala.reflect.macros._
+final case class AnnotationType[T](annotations: List[Any])
 
-sealed case class AnnotationType[T](annotations: List[Any])
-
-object AnnotationType {
-  implicit def apply[T]: AnnotationType[T] = macro applyImpl[T]
-
-  def applyImpl[T: c.WeakTypeTag](c: whitebox.Context): c.Tree = {
-    import c.universe._
-    val wtt = weakTypeTag[T]
-    val pre = wtt.tpe.asInstanceOf[TypeRef].pre
-
-    // Scala 2.12 & 2.13 macros seem to handle annotations differently
-    // Scala annotation works in both but Java annotations only works in 2.13
-    val saType = typeOf[scala.annotation.StaticAnnotation]
-    val jaType = typeOf[java.lang.annotation.Annotation]
-    // Annotation for Scala enumerations are on the outer object
-    val annotated = if (pre <:< typeOf[scala.Enumeration]) pre else wtt.tpe
-    val trees = annotated.typeSymbol.annotations.collect {
-      case t if t.tree.tpe <:< saType && !(t.tree.tpe <:< jaType) =>
-        // FIXME `t.tree` should work but somehow crashes the compiler
-        val q"new $n(..$args)" = t.tree
-        q"new $n(..$args)"
-    }
-
-    // Get Java annotations via reflection
-    val j = q"classOf[${annotated.typeSymbol.asClass}].getAnnotations.toList"
-    val annotations = q"_root_.scala.List(..$trees) ++ $j"
-
-    q"new _root_.magnolify.shared.AnnotationType[$wtt]($annotations)"
-  }
+object AnnotationType extends AnnotationTypeCompanionMacros {
+  def apply[T](implicit et: AnnotationType[T]): AnnotationType[T] = et
 }

--- a/shared/src/main/scala/magnolify/shared/EnumType.scala
+++ b/shared/src/main/scala/magnolify/shared/EnumType.scala
@@ -16,11 +16,7 @@
 
 package magnolify.shared
 
-import magnolia1._
-
 import scala.reflect.ClassTag
-import scala.reflect.macros._
-import scala.annotation.nowarn
 
 sealed trait EnumType[T] extends Serializable { self =>
   val name: String
@@ -43,7 +39,7 @@ sealed trait EnumType[T] extends Serializable { self =>
   }
 }
 
-object EnumType {
+object EnumType extends EnumTypeCompanionMacros {
   def apply[T](implicit et: EnumType[T]): EnumType[T] = et
   def apply[T](cm: CaseMapper)(implicit et: EnumType[T]): EnumType[T] = et.map(cm)
 
@@ -70,89 +66,13 @@ object EnumType {
     override def to(v: T): String = gMap(v)
   }
 
-  // ////////////////////////////////////////////////
-
-  // Java `enum`
   implicit def javaEnumType[T <: Enum[T]](implicit ct: ClassTag[T]): EnumType[T] = {
-    val cls: Class[_] = ct.runtimeClass
+    val cls = ct.runtimeClass.asInstanceOf[Class[T]]
     val n = ReflectionUtils.name[T]
     val ns = ReflectionUtils.namespace[T]
-    val map: Map[String, T] = cls
-      .getMethod("values")
-      .invoke(null)
-      .asInstanceOf[Array[T]]
-      .iterator
+    val map: Map[String, T] = cls.getEnumConstants.iterator
       .map(v => v.name() -> v)
       .toMap
     EnumType.create(n, ns, map.keys.toList, cls.getAnnotations.toList, map(_))
-  }
-
-  // ////////////////////////////////////////////////
-
-  // Scala `Enumeration`
-  implicit def scalaEnumType[T <: Enumeration#Value: AnnotationType]: EnumType[T] =
-    macro scalaEnumTypeImpl[T]
-
-  def scalaEnumTypeImpl[T: c.WeakTypeTag](
-    c: whitebox.Context
-  )(annotations: c.Expr[AnnotationType[T]]): c.Tree = {
-    import c.universe._
-    val wtt = weakTypeTag[T]
-    val ref = wtt.tpe.asInstanceOf[TypeRef]
-    val fn = ref.pre.typeSymbol.asClass.fullName
-    val idx = fn.lastIndexOf('.')
-    val n = fn.drop(idx + 1) // `object <Namespace> extends Enumeration`
-    val ns = fn.take(idx)
-    val list = q"${ref.pre.termSymbol}.values.toList.sortBy(_.id).map(_.toString)"
-    val map = q"${ref.pre.termSymbol}.values.map(x => x.toString -> x).toMap"
-
-    q"""
-        _root_.magnolify.shared.EnumType.create[$wtt](
-          $n, $ns, $list, $annotations.annotations, $map.apply(_))
-     """
-  }
-
-  // ////////////////////////////////////////////////
-
-  // Scala ADT
-  def adtEnumType[T]: EnumType[T] = macro Magnolia.gen[T]
-
-  implicit def gen[T](implicit lp: shapeless.LowPriority): EnumType[T] = macro genMacro[T]
-  @nowarn("msg=parameter value lp in method genMacro is never used")
-  def genMacro[T: c.WeakTypeTag](c: whitebox.Context)(lp: c.Tree): c.Tree = Magnolia.gen[T](c)
-
-  type Typeclass[T] = EnumType[T]
-
-  def join[T](caseClass: CaseClass[Typeclass, T]): Typeclass[T] = {
-    require(
-      caseClass.isObject,
-      s"Cannot derive EnumType[T] for case class ${caseClass.typeName.full}"
-    )
-    val n = caseClass.typeName.short
-    val ns = caseClass.typeName.owner
-    EnumType.create(
-      n,
-      ns,
-      List(n),
-      caseClass.annotations.toList,
-      _ => caseClass.rawConstruct(Nil)
-    )
-  }
-
-  def split[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] = {
-    val n = sealedTrait.typeName.short
-    val ns = sealedTrait.typeName.owner
-    val subs = sealedTrait.subtypes.map(_.typeclass)
-    val values = subs.flatMap(_.values).toList
-    val annotations = (sealedTrait.annotations ++ subs.flatMap(_.annotations)).toList
-    EnumType.create(
-      n,
-      ns,
-      values,
-      annotations,
-      // it is ok to use the inefficient find here because it will be called only once
-      // and cached inside an instance of EnumType
-      v => subs.find(_.name == v).get.from(v)
-    )
   }
 }

--- a/test/src/test/scala/magnolify/shared/EnumTypeSuite.scala
+++ b/test/src/test/scala/magnolify/shared/EnumTypeSuite.scala
@@ -24,7 +24,7 @@ class EnumTypeSuite extends MagnolifySuite {
     val et = ensureSerializable(implicitly[EnumType[JavaEnums.Color]])
     assertEquals(et.name, "Color")
     assertEquals(et.namespace, "magnolify.test.JavaEnums")
-    assertEquals(et.values, List("RED", "GREEN", "BLUE"))
+    assertEquals(et.values.toSet, Set("RED", "GREEN", "BLUE"))
     assertEquals(et.from("RED"), JavaEnums.Color.RED)
     assertEquals(et.to(JavaEnums.Color.RED), "RED")
     val ja = et.annotations.collect { case a: JavaAnnotation => a.value() }
@@ -35,7 +35,7 @@ class EnumTypeSuite extends MagnolifySuite {
     val et = ensureSerializable(implicitly[EnumType[ScalaEnums.Color.Type]])
     assertEquals(et.name, "Color")
     assertEquals(et.namespace, "magnolify.test.Simple.ScalaEnums")
-    assertEquals(et.values, List("Red", "Green", "Blue"))
+    assertEquals(et.values.toSet, Set("Red", "Green", "Blue"))
     assertEquals(et.from("Red"), ScalaEnums.Color.Red)
     assertEquals(et.to(ScalaEnums.Color.Red), "Red")
     val ja = et.annotations.collect { case a: JavaAnnotation => a.value() }
@@ -48,7 +48,7 @@ class EnumTypeSuite extends MagnolifySuite {
     val et = ensureSerializable(implicitly[EnumType[ADT.Color]])
     assertEquals(et.name, "Color")
     assertEquals(et.namespace, "magnolify.test.ADT")
-    assertEquals(et.values, List("Blue", "Green", "Red")) // ADTs are ordered alphabetically
+    assertEquals(et.values.toSet, Set("Blue", "Green", "Red"))
     assertEquals(et.from("Red"), ADT.Red)
     assertEquals(et.to(ADT.Red), "Red")
     // Magnolia does not capture Java annotations
@@ -60,7 +60,7 @@ class EnumTypeSuite extends MagnolifySuite {
     val et = ensureSerializable(implicitly[EnumType[ADT.Person]])
     assertEquals(et.name, "Person")
     assertEquals(et.namespace, "magnolify.test.ADT")
-    assertEquals(et.values, List("Aldrin", "Neil")) // ADTs are ordered alphabetically
+    assertEquals(et.values.toSet, Set("Aldrin", "Neil"))
     assertEquals(et.from("Aldrin"), ADT.Aldrin)
     assertEquals(et.to(ADT.Neil), "Neil")
   }

--- a/test/src/test/scala/magnolify/shims/ShimsSuite.scala
+++ b/test/src/test/scala/magnolify/shims/ShimsSuite.scala
@@ -30,7 +30,11 @@ class ShimsSuite extends MagnolifySuite {
     fc: FactoryCompat[Int, C[Int]]
   ): Unit = {
     property(className[C[Int]]) {
-      Prop.forAll { xs: List[Int] => fc.fromSpecific(xs).toList == xs }
+      Prop.forAll { (xs: List[Int]) =>
+        val b = fc.newBuilder
+        b ++= xs
+        ti(b.result()) == xs
+      }
     }
   }
 


### PR DESCRIPTION
cross build scala 3 test and shared modules

Some breaking changes:
- Derivation must me moved to dedicated class in specific scala folder
- All type-classes created with magnolia are created with `gen` under the type-class companion object
  - `AnnotationType.gen[T]: Annotationtype[T]`
  - `EnumType.gen[T]: EnumType[T]`
  
Thos should probably be merged into a `v0.7.x` branch to get started