### PR TITLE
[Proposal] Support properties in Avro

### DIFF
--- a/avro/src/main/scala/magnolify/avro/AvroType.scala
+++ b/avro/src/main/scala/magnolify/avro/AvroType.scala
@@ -119,7 +119,8 @@ object AvroField {
                 s.getElementType.addProp(k, v)
               }
               case Schema.Type.MAP => { case (s: Schema, (k: String, v: AnyRef)) =>
-                s.getValueType.addProp(k, v)
+                s.addProp(k, v) // Sets Key properties
+                s.getValueType.addProp(k, v) // Sets Value properties
               }
               case Schema.Type.UNION => { case (s: Schema, (k: String, v: AnyRef)) =>
                 s.getTypes.asScala.filterNot(_.getType == Schema.Type.NULL).foreach(_.addProp(k, v))

--- a/avro/src/main/scala/magnolify/avro/AvroType.scala
+++ b/avro/src/main/scala/magnolify/avro/AvroType.scala
@@ -66,24 +66,16 @@ sealed trait AvroField[T] extends Serializable { self =>
 
   protected def buildSchema(cm: CaseMapper): Schema
 
-  def schema(cm: CaseMapper): Schema = {
-    def hasProperties(schema: Schema): Boolean = schema.getType match {
-      case Schema.Type.ARRAY => schema.getElementType.hasProps
-      case Schema.Type.MAP   => schema.getValueType.hasProps
-      case Schema.Type.UNION => schema.getTypes.asScala.exists(_.hasProps)
-      case _                 => schema.hasProps
-    }
-
+  def schema(cm: CaseMapper): Schema =
     schemaCache.get(cm.uuid) match {
       case Some(cachedSchema) => cachedSchema
       case None =>
         val schema = buildSchema(cm)
-        if (!hasProperties(schema)) {
+        if (schema.getType == Schema.Type.RECORD) {
           schemaCache.put(cm.uuid, schema)
         }
         schema
     }
-  }
 
   // Convert default `T` to Avro schema default value
   def makeDefault(d: T)(cm: CaseMapper): Any = to(d)(cm)

--- a/avro/src/main/scala/magnolify/avro/package.scala
+++ b/avro/src/main/scala/magnolify/avro/package.scala
@@ -18,4 +18,8 @@ package magnolify
 
 package object avro {
   type doc = shared.doc
+
+  case class property(kv: (String, AnyRef))
+      extends scala.annotation.StaticAnnotation
+      with Serializable
 }

--- a/avro/src/test/scala/magnolify/avro/AvroTypeSuite.scala
+++ b/avro/src/test/scala/magnolify/avro/AvroTypeSuite.scala
@@ -333,22 +333,18 @@ class AvroTypeSuite extends MagnolifySuite {
     val schema = at.schema
 
     assert(
-      schema.toString ==
-        """
+      schema == Schema.parse("""
         |{
         |  "type":"record",
         |  "name":"Properties",
         |  "namespace":"magnolify.avro",
-        |    "fields":[
-        |       {"name":"str","type":["null",{"type":"string","a":"b","c":"d"}]},
-        |       {"name":"list","type":{"type":"array","items":{"type":"string","g":"h"}},"default":[]},
-        |       {"name":"map","type":{"type":"map","values":{"i":"j"}},"default":{}},
-        |       {"name":"nested","type":
-        |         {"type":"record","name":"PropertiesNested","fields":[
-        |           {"name":"int","type":{"type":"int","e":"f"}}
-        |         ]}
-        |    ]}
-        |""".stripMargin
+        |  "fields":[
+        |     {"name":"str","type":["null",{"type":"string","a":"b","c":"d"}]},
+        |     {"name":"list","type":{"type":"array","items":{"type":"string","g":"h"}},"default":[]},
+        |     {"name":"map","type":{"type":"map","values":{"type":"string","i":"j"}},"default":{}},
+        |     {"name":"nested","type":{"type":"record","name":"PropertiesNested","fields":[{"name":"int","type":{"type":"int","e":"f"}}]}}
+        |  ]}
+        |""".stripMargin)
     )
   }
 }

--- a/avro/src/test/scala/magnolify/avro/AvroTypeSuite.scala
+++ b/avro/src/test/scala/magnolify/avro/AvroTypeSuite.scala
@@ -340,7 +340,7 @@ class AvroTypeSuite extends MagnolifySuite {
         |  "fields":[
         |     {"name":"str","type":["null",{"type":"string","${GenericData.STRING_PROP}":"String","extraProp":"foo"}]},
         |     {"name":"list","type":{"type":"array","items":{"type":"string","${GenericData.STRING_PROP}":"String"}},"default":[]},
-        |     {"name":"map","type":{"type":"map","values":{"type":"string","${GenericData.STRING_PROP}":"String"}},"default":{}},
+        |     {"name":"map","type":{"type":"map","values":{"type":"string","${GenericData.STRING_PROP}":"String"},"${GenericData.STRING_PROP}":"String"},"default":{}},
         |     {"name":"nested","type":{"type":"record","name":"PropertiesNested","fields":[
         |       {"name":"str","type":{"type":"string","${GenericData.STRING_PROP}":"String"}}
         |     ]}}

--- a/avro/src/test/scala/magnolify/avro/AvroTypeSuite.scala
+++ b/avro/src/test/scala/magnolify/avro/AvroTypeSuite.scala
@@ -329,7 +329,7 @@ class AvroTypeSuite extends MagnolifySuite {
   }
 
   test("Properties") {
-    val at: AvroType[Properties] = AvroType[Properties]
+    val at: AvroType[Properties] = ensureSerializable(AvroType[Properties])
 
     assert(
       at.schema == new Schema.Parser().parse(s"""

--- a/avro/src/test/scala/magnolify/avro/AvroTypeSuite.scala
+++ b/avro/src/test/scala/magnolify/avro/AvroTypeSuite.scala
@@ -330,10 +330,9 @@ class AvroTypeSuite extends MagnolifySuite {
 
   test("Properties") {
     val at: AvroType[Properties] = AvroType[Properties]
-    val schema = at.schema
 
     assert(
-      schema == Schema.parse("""
+      at.schema == new Schema.Parser().parse("""
         |{
         |  "type":"record",
         |  "name":"Properties",

--- a/avro/src/test/scala/magnolify/avro/AvroTypeSuite.scala
+++ b/avro/src/test/scala/magnolify/avro/AvroTypeSuite.scala
@@ -327,8 +327,39 @@ class AvroTypeSuite extends MagnolifySuite {
       at(BigDec(BigDecimal("3.14159265358979323846")))
     }
   }
+
+  test("Properties") {
+    val at: AvroType[Properties] = AvroType[Properties]
+    val schema = at.schema
+
+    assert(
+      schema.toString ==
+        """
+        |{
+        |  "type":"record",
+        |  "name":"Properties",
+        |  "namespace":"magnolify.avro",
+        |    "fields":[
+        |       {"name":"str","type":["null",{"type":"string","a":"b","c":"d"}]},
+        |       {"name":"list","type":{"type":"array","items":{"type":"string","g":"h"}},"default":[]},
+        |       {"name":"map","type":{"type":"map","values":{"i":"j"}},"default":{}},
+        |       {"name":"nested","type":
+        |         {"type":"record","name":"PropertiesNested","fields":[
+        |           {"name":"int","type":{"type":"int","e":"f"}}
+        |         ]}
+        |    ]}
+        |""".stripMargin
+    )
+  }
 }
 
+case class PropertiesNested(@property("e" -> "f") int: Int)
+case class Properties(
+  @property("a" -> "b") @property("c" -> "d") str: Option[String],
+  @property("g" -> "h") list: List[String],
+  @property("i" -> "j") map: Map[String, String],
+  nested: PropertiesNested
+)
 case class Unsafe(b: Byte, c: Char, s: Short)
 case class AvroTypes(ba: Array[Byte], u: Unit)
 case class MapPrimitive(m: Map[String, Int])


### PR DESCRIPTION
Add supports setting Avro field-level properties.

Running jmh benchmark:

```sh
sbt "jmh/jmh:run -i 10 -wi 10 -f1 -t1 .*avro.*" 
```

|  | Main Branch | PR branch  |
| ----- | ---- | -----|
| to (CC => GenericRecord) | 2196.517 | 2540.217 |
| from (GenericRecord => CC) | 932.371 | 935.241  |
| schema | 6557.597 |  7150.372 |

When a single property is added to the jmh test case class, these figures jump to:

|  | Main Branch | PR branch  |
| ----- | ---- | -----|
| to (CC => GenericRecord) | n/a | 1984.465  |
| from (GenericRecord => CC) | n/a  | 928.057  |
| schema | n/a  |  8831.822 |

IMO the main hit to performance is that we can't cache leaf-level fields in the schemaCache--this is because the properties will start to override each other when set. Unfortunately Avro doesn't have a method to *remove* properties so ways to mitigate this are a bit limited.

Leaving this as a PROPOSAL because it does incur a small perf penalty and there might be simpler ways to solve this issue (i.e., defining separate `AvroField` implicit vals for `String` vs `Utf8` classes, and setting properties accordingly during `buildSchema`.