### PR TITLE
Convert from GenericRecord using field name

### DIFF
--- a/avro/src/main/scala/magnolify/avro/AvroType.scala
+++ b/avro/src/main/scala/magnolify/avro/AvroType.scala
@@ -136,7 +136,7 @@ object AvroField {
 
         override def from(v: GenericRecord)(cm: CaseMapper): T =
           caseClass.construct { p =>
-            p.typeclass.fromAny(v.get(p.index))(cm)
+            p.typeclass.fromAny(v.get(cm.map(p.label)))(cm)
           }
 
         override def to(v: T)(cm: CaseMapper): GenericRecord =


### PR DESCRIPTION
When order of fields in case class does not match the order of fields in Avro file AvroType.from will fail
Reverting it to the way it was with previous magnolia