### PR TITLE
Use `putUnencodedChars` for Funneling strings.

### DIFF
--- a/guava/src/main/scala/magnolify/guava/semiauto/FunnelDerivation.scala
+++ b/guava/src/main/scala/magnolify/guava/semiauto/FunnelDerivation.scala
@@ -20,6 +20,8 @@ import com.google.common.base.Charsets
 import com.google.common.hash.{Funnel, Funnels, PrimitiveSink}
 import magnolia1._
 
+import scala.annotation.nowarn
+
 object FunnelDerivation {
   type Typeclass[T] = Funnel[T]
 
@@ -29,7 +31,7 @@ object FunnelDerivation {
         val p = caseClass.parameters.head
         p.typeclass.funnel(p.dereference(from), into)
       } else if (caseClass.parameters.isEmpty) {
-        into.putString(caseClass.typeName.short, Charsets.UTF_8)
+        into.putString(caseClass.typeName.short, Charsets.UTF_8): @nowarn
       } else {
         caseClass.parameters.foreach { p =>
           // inject index to distinguish cases like `(Some(1), None)` and `(None, Some(1))`
@@ -59,10 +61,10 @@ trait FunnelImplicits {
   implicit val intFunnel: Funnel[Int] = Funnels.integerFunnel().asInstanceOf[Funnel[Int]]
   implicit val longFunnel: Funnel[Long] = Funnels.longFunnel().asInstanceOf[Funnel[Long]]
   implicit val bytesFunnel: Funnel[Array[Byte]] = Funnels.byteArrayFunnel()
-  implicit val booleanFunnel: Funnel[Boolean] = funnel[Boolean](_.putBoolean(_))
-  implicit val byteFunnel: Funnel[Byte] = funnel[Byte](_.putByte(_))
-  implicit val charFunnel: Funnel[Char] = funnel[Char](_.putChar(_))
-  implicit val shortFunnel: Funnel[Short] = funnel[Short](_.putShort(_))
+  implicit val booleanFunnel: Funnel[Boolean] = funnel[Boolean](_.putBoolean(_): @nowarn)
+  implicit val byteFunnel: Funnel[Byte] = funnel[Byte](_.putByte(_): @nowarn)
+  implicit val charFunnel: Funnel[Char] = funnel[Char](_.putChar(_): @nowarn)
+  implicit val shortFunnel: Funnel[Short] = funnel[Short](_.putShort(_): @nowarn)
 
   implicit def charSequenceFunnel[T <: CharSequence]: Funnel[T] =
     Funnels.unencodedCharsFunnel().asInstanceOf[Funnel[T]]
@@ -79,6 +81,6 @@ trait FunnelImplicits {
         i += 1
       }
       // inject size to distinguish `None`, `Some("")`, and `List("", "", ...)`
-      sink.putInt(i)
+      sink.putInt(i): @nowarn
     }
 }

--- a/guava/src/main/scala/magnolify/guava/semiauto/FunnelDerivation.scala
+++ b/guava/src/main/scala/magnolify/guava/semiauto/FunnelDerivation.scala
@@ -59,13 +59,13 @@ trait FunnelImplicits {
   implicit val intFunnel: Funnel[Int] = Funnels.integerFunnel().asInstanceOf[Funnel[Int]]
   implicit val longFunnel: Funnel[Long] = Funnels.longFunnel().asInstanceOf[Funnel[Long]]
   implicit val bytesFunnel: Funnel[Array[Byte]] = Funnels.byteArrayFunnel()
-  implicit val charSequenceFunnel: Funnel[CharSequence] = Funnels.unencodedCharsFunnel()
-
   implicit val booleanFunnel: Funnel[Boolean] = funnel[Boolean](_.putBoolean(_))
-  implicit val stringFunnel: Funnel[String] = Funnels.unencodedCharsFunnel.asInstanceOf[Funnel[String]]
   implicit val byteFunnel: Funnel[Byte] = funnel[Byte](_.putByte(_))
   implicit val charFunnel: Funnel[Char] = funnel[Char](_.putChar(_))
   implicit val shortFunnel: Funnel[Short] = funnel[Short](_.putShort(_))
+
+  implicit def charSequenceFunnel[T <: CharSequence]: Funnel[T] =
+    Funnels.unencodedCharsFunnel().asInstanceOf[Funnel[T]]
 
   // There is an implicit Option[T] => Iterable[T]
   implicit def iterableFunnel[T, C[_]](implicit

--- a/guava/src/main/scala/magnolify/guava/semiauto/FunnelDerivation.scala
+++ b/guava/src/main/scala/magnolify/guava/semiauto/FunnelDerivation.scala
@@ -62,7 +62,7 @@ trait FunnelImplicits {
   implicit val charSequenceFunnel: Funnel[CharSequence] = Funnels.unencodedCharsFunnel()
 
   implicit val booleanFunnel: Funnel[Boolean] = funnel[Boolean](_.putBoolean(_))
-  implicit val stringFunnel: Funnel[String] = funnel[String](_.putString(_, Charsets.UTF_8))
+  implicit val stringFunnel: Funnel[String] = Funnels.unencodedCharsFunnel.asInstanceOf[Funnel[String]]
   implicit val byteFunnel: Funnel[Byte] = funnel[Byte](_.putByte(_))
   implicit val charFunnel: Funnel[Char] = funnel[Char](_.putChar(_))
   implicit val shortFunnel: Funnel[Short] = funnel[Short](_.putShort(_))

--- a/guava/src/test/scala/magnolify/guava/FunnelDerivationSuite.scala
+++ b/guava/src/test/scala/magnolify/guava/FunnelDerivationSuite.scala
@@ -33,7 +33,6 @@ import java.io.ObjectOutputStream
 import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
-import java.nio.charset.StandardCharsets
 import java.time.Duration
 import scala.reflect._
 
@@ -82,12 +81,7 @@ class FunnelDerivationSuite extends MagnolifySuite {
 
     val ois = new ObjectInputStream(new ByteArrayInputStream(sink.toBytes))
     assert(ois.readInt() == 0)
-    assert(ois.readChar() == 'S')
-    assert(ois.readChar() == 't')
-    assert(ois.readChar() == 'r')
-    assert(ois.readChar() == 'i')
-    assert(ois.readChar() == 'n')
-    assert(ois.readChar() == 'g')
+    "String".foreach(c => assert(ois.readChar() == c))
     assert(ois.available() == 0)
   }
 
@@ -168,9 +162,6 @@ class BytesSink extends PrimitiveSink {
     this
   }
 
-  override def putString(charSequence: CharSequence, charset: Charset): PrimitiveSink = {
-    require(charset == StandardCharsets.UTF_8)
-    oos.writeUTF(charSequence.toString)
-    this
-  }
+  override def putString(charSequence: CharSequence, charset: Charset): PrimitiveSink =
+    putBytes(charset.encode(charSequence.toString))
 }

--- a/guava/src/test/scala/magnolify/guava/FunnelDerivationSuite.scala
+++ b/guava/src/test/scala/magnolify/guava/FunnelDerivationSuite.scala
@@ -82,7 +82,12 @@ class FunnelDerivationSuite extends MagnolifySuite {
 
     val ois = new ObjectInputStream(new ByteArrayInputStream(sink.toBytes))
     assert(ois.readInt() == 0)
-    assert(ois.readUTF() == "String")
+    assert(ois.readChar() == 'S')
+    assert(ois.readChar() == 't')
+    assert(ois.readChar() == 'r')
+    assert(ois.readChar() == 'i')
+    assert(ois.readChar() == 'n')
+    assert(ois.readChar() == 'g')
     assert(ois.available() == 0)
   }
 


### PR DESCRIPTION
As per the warning on [PrimitiveSink.putString](https://javadoc.io/doc/com.google.guava/guava/latest/com/google/common/hash/PrimitiveSink.html#putString(java.lang.CharSequence,java.nio.charset.Charset)) JavaDoc:
> Warning: This method, which reencodes the input before processing it, is useful only for cross-language compatibility. For other use cases, prefer putUnencodedChars(java.lang.CharSequence), which is faster, produces the same output across Java releases, and processes every char in the input, even if some are invalid.

Or maybe leave this out and let people make their own decision as to what they want for the `Funnel[String]` instance?