### PR TITLE
Force avro String type in generated schema

### DIFF
--- a/avro/src/main/scala/magnolify/avro/AvroType.scala
+++ b/avro/src/main/scala/magnolify/avro/AvroType.scala
@@ -190,6 +190,7 @@ object AvroField {
 
   private def id[T](tpe: Schema.Type): AvroField[T] = aux[T, T, T](tpe)(identity)(identity)
 
+  implicit val afNull: AvroField[Null] = aux2[Null, Null](Schema.Type.NULL)(_ => null)(_ => null)
   implicit val afBoolean: AvroField[Boolean] = id[Boolean](Schema.Type.BOOLEAN)
   implicit val afInt: AvroField[Int] = id[Int](Schema.Type.INT)
   implicit val afLong: AvroField[Long] = id[Long](Schema.Type.LONG)

--- a/avro/src/main/scala/magnolify/avro/logical/package.scala
+++ b/avro/src/main/scala/magnolify/avro/logical/package.scala
@@ -102,8 +102,8 @@ package object logical {
 
     // DATETIME -> sqlType: DATETIME
     implicit val afBigQueryDatetime: AvroField[LocalDateTime] =
-      AvroField.logicalType[String](new org.apache.avro.LogicalType(DateTimeTypeName))(s =>
-        LocalDateTime.from(DatetimeParser.parse(s))
+      AvroField.logicalType[CharSequence](new org.apache.avro.LogicalType(DateTimeTypeName))(cs =>
+        LocalDateTime.from(DatetimeParser.parse(cs))
       )(DatetimePrinter.format)
   }
 }

--- a/avro/src/test/scala/magnolify/avro/AvroTypeSuite.scala
+++ b/avro/src/test/scala/magnolify/avro/AvroTypeSuite.scala
@@ -169,7 +169,7 @@ class AvroTypeSuite extends MagnolifySuite {
     val at: AvroType[AvroTypes] = AvroType[AvroTypes]
     val copier = new Copier(at.schema)
     // original uses String as CharSequence implementation
-    val original = AvroTypes("String", "CharSequence", Array.emptyByteArray)
+    val original = AvroTypes("String", "CharSequence", Array.emptyByteArray, null)
     val copy = at.from(copier.apply(at.to(original)))
     // copy uses avro Utf8 as CharSequence implementation
     assert(original != copy)
@@ -367,7 +367,7 @@ class AvroTypeSuite extends MagnolifySuite {
 }
 
 case class Unsafe(b: Byte, c: Char, s: Short)
-case class AvroTypes(str: String, cs: CharSequence, ba: Array[Byte])
+case class AvroTypes(str: String, cs: CharSequence, ba: Array[Byte], n: Null)
 case class MapPrimitive(strMap: Map[String, Int], charSeqMap: Map[CharSequence, Int])
 case class MapNested(m: Map[String, Nested], charSeqMap: Map[CharSequence, Nested])
 

--- a/avro/src/test/scala/magnolify/avro/AvroTypeSuite.scala
+++ b/avro/src/test/scala/magnolify/avro/AvroTypeSuite.scala
@@ -34,6 +34,7 @@ import org.apache.avro.Schema
 import org.apache.avro.generic._
 import org.apache.avro.io.DecoderFactory
 import org.apache.avro.io.EncoderFactory
+import org.apache.avro.util.Utf8
 import org.scalacheck._
 
 import java.io.ByteArrayInputStream
@@ -163,6 +164,18 @@ class AvroTypeSuite extends MagnolifySuite {
   test[UnsafeEnums]
   test[Custom]
   test[AvroTypes]
+
+  test("String vs CharSequence with avro.java.string property") {
+    val at: AvroType[AvroTypes] = AvroType[AvroTypes]
+    val copier = new Copier(at.schema)
+    // original uses String as CharSequence implementation
+    val original = AvroTypes("String", "CharSequence", Array.emptyByteArray)
+    val copy = at.from(copier.apply(at.to(original)))
+    // copy uses avro Utf8 as CharSequence implementation
+    assert(original != copy)
+    assert(copy.str.isInstanceOf[String])
+    assert(copy.cs.isInstanceOf[Utf8])
+  }
 
   test("AnyVal") {
     implicit val at: AvroType[HasValueClass] = AvroType[HasValueClass]

--- a/avro/src/test/scala/magnolify/avro/AvroTypeSuite.scala
+++ b/avro/src/test/scala/magnolify/avro/AvroTypeSuite.scala
@@ -31,10 +31,7 @@ import magnolify.shared.TestEnumType._
 import magnolify.test.Simple._
 import magnolify.test._
 import org.apache.avro.Schema
-import org.apache.avro.generic.GenericDatumReader
-import org.apache.avro.generic.GenericDatumWriter
-import org.apache.avro.generic.GenericRecord
-import org.apache.avro.generic.GenericRecordBuilder
+import org.apache.avro.generic._
 import org.apache.avro.io.DecoderFactory
 import org.apache.avro.io.EncoderFactory
 import org.scalacheck._
@@ -55,20 +52,57 @@ import scala.reflect._
 import scala.util.Try
 
 class AvroTypeSuite extends MagnolifySuite {
+
+  // Best effort for GenericRecord eq
+  // will fail if model contains List[CharSequence] / Map[_, CharSequence] / Option[CharSequence]
+  val eqr: Eq[GenericRecord] = new Eq[GenericRecord] {
+    private def read[T](f: Schema.Field)(r: GenericRecord): T = r.get(f.pos()).asInstanceOf[T]
+
+    override def eqv(x: GenericRecord, y: GenericRecord): Boolean = {
+      x.getSchema == y.getSchema && x.getSchema.getFields.asScala.forall { f =>
+        val fs = f.schema()
+        fs.getType match {
+          case Schema.Type.ARRAY if fs.getElementType.getType == Schema.Type.RECORD =>
+            val typedRead = read[java.util.AbstractList[GenericRecord]](f) _
+            val xm = typedRead(x).asScala.toList
+            val ym = typedRead(y).asScala.toList
+            Eq.catsKernelEqForList[GenericRecord](this).eqv(xm, ym)
+          case Schema.Type.MAP if fs.getValueType.getType == Schema.Type.RECORD =>
+            val typedRead = read[java.util.Map[CharSequence, GenericRecord]](f) _
+            val xm = typedRead(x).asScala.map { case (k, v) => k.toString -> v }.toMap
+            val ym = typedRead(y).asScala.map { case (k, v) => k.toString -> v }.toMap
+            Eq.catsKernelEqForMap[String, GenericRecord](this).eqv(xm, ym)
+          case Schema.Type.ARRAY =>
+            val typedRead = read[java.util.AbstractList[_]](f) _
+            val xm = typedRead(x).asScala.toList
+            val ym = typedRead(y).asScala.toList
+            xm == ym
+          case Schema.Type.MAP =>
+            val typedRead = read[java.util.Map[CharSequence, _]](f) _
+            val xm = typedRead(x).asScala.map { case (k, v) => k.toString -> v }.toMap
+            val ym = typedRead(y).asScala.map { case (k, v) => k.toString -> v }.toMap
+            xm == ym
+          case Schema.Type.STRING if f.getProp(GenericData.STRING_PROP) != "String" =>
+            read[CharSequence](f)(x).toString == read[CharSequence](f)(y).toString
+          case _ =>
+            read[AnyRef](f)(x) == read[AnyRef](f)(y)
+        }
+      }
+    }
+  }
+
   private def test[T: Arbitrary: ClassTag](implicit
     t: AvroType[T],
-    eqt: Eq[T],
-    eqr: Eq[GenericRecord] = Eq.instance(_ == _)
+    eq: Eq[T]
   ): Unit = {
     val tpe = ensureSerializable(t)
-    // FIXME: test schema
     val copier = new Copier(tpe.schema)
     property(className[T]) {
       Prop.forAll { t: T =>
         val r = tpe(t)
         val rCopy = copier(r)
         val copy = tpe(rCopy)
-        Prop.all(eqt.eqv(t, copy), eqr.eqv(r, rCopy))
+        Prop.all(eq.eqv(t, copy), eqr.eqv(r, rCopy))
       }
     }
   }
@@ -140,18 +174,8 @@ class AvroTypeSuite extends MagnolifySuite {
     assert(record.get("vc") == "String")
   }
 
-  {
-    def f(r: GenericRecord): List[(String, Any)] =
-      r.get("m")
-        .asInstanceOf[java.util.Map[CharSequence, Any]]
-        .asScala
-        .toList
-        .map(kv => (kv._1.toString, kv._2))
-        .sortBy(_._1)
-    implicit val eqMapPrimitive: Eq[GenericRecord] = Eq.instance((x, y) => f(x) == f(y))
-    test[MapPrimitive]
-    test[MapNested]
-  }
+  test[MapPrimitive]
+  test[MapNested]
 
   test[Logical]
 
@@ -330,9 +354,9 @@ class AvroTypeSuite extends MagnolifySuite {
 }
 
 case class Unsafe(b: Byte, c: Char, s: Short)
-case class AvroTypes(ba: Array[Byte], u: Unit)
-case class MapPrimitive(m: Map[String, Int])
-case class MapNested(m: Map[String, Nested])
+case class AvroTypes(str: String, cs: CharSequence, ba: Array[Byte])
+case class MapPrimitive(strMap: Map[String, Int], charSeqMap: Map[CharSequence, Int])
+case class MapNested(m: Map[String, Nested], charSeqMap: Map[CharSequence, Nested])
 
 case class Logical(u: UUID, d: LocalDate)
 case class LogicalMicros(i: Instant, t: LocalTime, dt: LocalDateTime)

--- a/cats/src/test/scala/magnolify/cats/TestEq.scala
+++ b/cats/src/test/scala/magnolify/cats/TestEq.scala
@@ -29,6 +29,7 @@ import java.time._
 object TestEq {
 
   // other
+  implicit lazy val eqNull: Eq[Null] = Eq.allEqual
   implicit lazy val eqUri: Eq[URI] = Eq.fromUniversalEquals
   implicit lazy val eqArray: Eq[Array[Int]] = Eq.by(_.toList)
   implicit def eqIterable[T, C[_]](implicit eq: Eq[T], ti: C[T] => Iterable[T]): Eq[C[T]] =

--- a/cats/src/test/scala/magnolify/cats/TestEq.scala
+++ b/cats/src/test/scala/magnolify/cats/TestEq.scala
@@ -38,6 +38,14 @@ object TestEq {
       xs.size == ys.size && (xs zip ys).forall((eq.eqv _).tupled)
     }
 
+  // java
+  implicit lazy val eqCharSequence: Eq[CharSequence] = Eq.by(_.toString)
+  implicit def eqCharSeqMap[T: Eq]: Eq[Map[CharSequence, T]] = Eq.by { m =>
+    // Map[CharSequence, T] should not be used for lookups as key equality is not guarantee
+    // Can only be used as a key value list
+    m.map { case (k, v) => k.toString -> v }
+  }
+
   // time
   implicit lazy val eqInstant: Eq[Instant] = Eq.by(_.toEpochMilli)
   implicit lazy val eqLocalDate: Eq[LocalDate] = Eq.by(_.toEpochDay)

--- a/parquet/src/test/scala/magnolify/parquet/AvroParquetSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/AvroParquetSuite.scala
@@ -30,8 +30,7 @@ import magnolify.scalacheck.auto._
 import magnolify.scalacheck.TestArbitrary._
 import magnolify.test._
 import magnolify.test.Simple._
-
-import org.apache.avro.generic.GenericRecord
+import org.apache.avro.generic.{GenericData, GenericDatumReader, GenericRecord}
 import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.avro.{
   AvroParquetReader,
@@ -87,6 +86,8 @@ class AvroParquetSuite extends MagnolifySuite {
         val in = new TestInputFile(out.getBytes)
         val conf = new Configuration()
         AvroReadSupport.setAvroDataSupplier(conf, classOf[GenericDataSupplier])
+        // read with AvroType schema instead of parquet writer one
+        AvroReadSupport.setAvroReadSchema(conf, at.schema)
         val reader = AvroParquetReader.builder[GenericRecord](in).withConf(conf).build()
 
         val copy = reader.read()

--- a/scalacheck/src/test/scala/magnolify/scalacheck/TestArbitrary.scala
+++ b/scalacheck/src/test/scala/magnolify/scalacheck/TestArbitrary.scala
@@ -27,6 +27,9 @@ import java.time._
 import java.net.URI
 
 object TestArbitrary {
+  // null
+  implicit lazy val arbNull: Arbitrary[Null] = Arbitrary(Gen.const(null))
+
   // java
   implicit lazy val arbCharSequence: Arbitrary[CharSequence] = Arbitrary {
     Gen.listOf(Gen.asciiChar).map { cs =>

--- a/scalacheck/src/test/scala/magnolify/scalacheck/TestArbitrary.scala
+++ b/scalacheck/src/test/scala/magnolify/scalacheck/TestArbitrary.scala
@@ -27,6 +27,15 @@ import java.time._
 import java.net.URI
 
 object TestArbitrary {
+  // java
+  implicit lazy val arbCharSequence: Arbitrary[CharSequence] = Arbitrary {
+    Gen.listOf(Gen.asciiChar).map { cs =>
+      val sb = new StringBuilder()
+      sb.appendAll(cs)
+      sb
+    }
+  }
+
   // time
   implicit lazy val arbInstant: Arbitrary[Instant] =
     Arbitrary(Gen.posNum[Long].map(Instant.ofEpochMilli))
@@ -42,12 +51,10 @@ object TestArbitrary {
     Arbitrary(Gen.posNum[Long].map(Duration.ofMillis))
 
   // enum
-  implicit lazy val arbJavaEnum: Arbitrary[JavaEnums.Color] = Arbitrary(
-    Gen.oneOf(JavaEnums.Color.values.toSeq)
-  )
-  implicit lazy val arbScalaEnums: Arbitrary[ScalaEnums.Color.Type] = Arbitrary(
-    Gen.oneOf(ScalaEnums.Color.values)
-  )
+  implicit lazy val arbJavaEnum: Arbitrary[JavaEnums.Color] =
+    Arbitrary(Gen.oneOf(JavaEnums.Color.values.toSeq))
+  implicit lazy val arbScalaEnums: Arbitrary[ScalaEnums.Color.Type] =
+    Arbitrary(Gen.oneOf(ScalaEnums.Color.values))
   implicit def arbUnsafeEnum[T](implicit arb: Arbitrary[T]): Arbitrary[UnsafeEnum[T]] = Arbitrary {
     Gen.oneOf(
       arb.arbitrary.map(UnsafeEnum.Known.apply),

--- a/tools/src/main/scala/magnolify/tools/AvroParser.scala
+++ b/tools/src/main/scala/magnolify/tools/AvroParser.scala
@@ -103,7 +103,7 @@ object AvroParser extends SchemaParser[avro.Schema] {
     case Type.FLOAT   => Primitive.Float
     case Type.DOUBLE  => Primitive.Double
     case Type.BOOLEAN => Primitive.Boolean
-    case Type.NULL    => Primitive.Unit
+    case Type.NULL    => Primitive.Null
 
     case _ =>
       throw new IllegalArgumentException(s"Unsupported schema $schema")

--- a/tools/src/main/scala/magnolify/tools/Schema.scala
+++ b/tools/src/main/scala/magnolify/tools/Schema.scala
@@ -50,7 +50,7 @@ case class Enum(
 ) extends Nested
 
 object Primitive {
-  case object Unit extends Primitive
+  case object Null extends Primitive
   case object Boolean extends Primitive
   case object Char extends Primitive
   case object Byte extends Primitive

--- a/tools/src/test/scala/magnolify/tools/AvroParserSuite.scala
+++ b/tools/src/test/scala/magnolify/tools/AvroParserSuite.scala
@@ -51,7 +51,7 @@ class AvroParserSuite extends MagnolifySuite {
         "d" -> Primitive.Double,
         "ba" -> Primitive.Bytes,
         "s" -> Primitive.String,
-        "u" -> Primitive.Unit
+        "n" -> Primitive.Null
       ).map(kv => Field(kv._1, None, kv._2, Required))
     )
   )
@@ -179,7 +179,7 @@ object AvroParserSuite {
     d: Double,
     ba: Array[Byte],
     s: String,
-    u: Unit
+    n: Null
   )
 
   case class Enums(e: Color.Value)

--- a/tools/src/test/scala/magnolify/tools/SchemaPrinterSuite.scala
+++ b/tools/src/test/scala/magnolify/tools/SchemaPrinterSuite.scala
@@ -24,7 +24,7 @@ class SchemaPrinterSuite extends MagnolifySuite {
 
   test("Primitive") {
     List(
-      Primitive.Unit,
+      Primitive.Null,
       Primitive.Boolean,
       Primitive.Char,
       Primitive.Byte,


### PR DESCRIPTION
scala/java `String` will be represented in with the `"avro.java.string": "String"` property in the avro schema.

Logical types baked by avro string should be created using the `CharSequence` type as the property is forbidden there (exception is thrown when building the schema)