### PR TITLE
Respect case mapper for field documentation in parquet avro schema

### DIFF
--- a/parquet/src/main/scala/magnolify/parquet/ParquetType.scala
+++ b/parquet/src/main/scala/magnolify/parquet/ParquetType.scala
@@ -90,7 +90,8 @@ object ParquetType {
         @transient override lazy val avroSchema: AvroSchema = {
           val s = new AvroSchemaConverter().convert(schema)
           // add doc to avro schema
-          SchemaUtil.deepCopy(s, f.typeDoc, f.fieldDocs.get)
+          val fieldDocs = f.fieldDocs(cm)
+          SchemaUtil.deepCopy(s, f.typeDoc, fieldDocs.get)
         }
 
         override val avroCompat: Boolean =

--- a/parquet/src/test/scala/magnolify/parquet/AvroParquetSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/AvroParquetSuite.scala
@@ -21,7 +21,7 @@ import cats._
 import magnolify.cats.auto._
 import magnolify.cats.TestEq._
 import magnolify.avro.AvroType
-import magnolify.shared.doc
+import magnolify.shared.{doc, CaseMapper}
 import magnolify.avro.unsafe._
 import magnolify.parquet.unsafe._
 import magnolify.parquet.ParquetArray.AvroCompat._
@@ -44,8 +44,24 @@ import org.scalacheck._
 import scala.reflect.ClassTag
 
 class AvroParquetSuite extends MagnolifySuite {
+
+  private def test[T: Arbitrary: ClassTag]()(implicit
+    at: AvroType[T],
+    tpe: ParquetType[T],
+    eq: Eq[T]
+  ): Unit = test[T](List.empty)
+
   private def test[T: Arbitrary: ClassTag](
-    schemaErrors: List[String] = List.empty
+    schemaErrors: List[String]
+  )(implicit
+    at: AvroType[T],
+    tpe: ParquetType[T],
+    eq: Eq[T]
+  ): Unit = test[T](className[T], schemaErrors)
+
+  private def test[T: Arbitrary](
+    name: String,
+    schemaErrors: List[String]
   )(implicit
     at: AvroType[T],
     tpe: ParquetType[T],
@@ -55,8 +71,6 @@ class AvroParquetSuite extends MagnolifySuite {
     val parquetSchema = tpe.schema
     val avroSchema = tpe.avroSchema
     val pt = ensureSerializable(tpe)
-
-    val name = className[T]
 
     property(s"$name.avro2parquet") {
       Prop.forAll { t: T =>
@@ -194,6 +208,21 @@ class AvroParquetSuite extends MagnolifySuite {
       "root.nested 'namespace' are different 'magnolify.parquet' != 'null'"
     )
   )
+
+  {
+    val upperCaseMapper = CaseMapper(_.toUpperCase())
+    implicit val at = AvroType[AvroParquetWithNestedAnnotations](upperCaseMapper)
+    implicit val pt = ParquetType[AvroParquetWithNestedAnnotations](upperCaseMapper)
+    test[AvroParquetWithNestedAnnotations](
+      "AvroParquetWithNestedAnnotations and CaseMapper",
+      List(
+        "root.NESTED 'name' are different 'AvroParquetWithAnnotations' != 'NESTED'",
+        "root.NESTED 'doc' are different 'Should be ignored' != 'null'",
+        "root.NESTED 'namespace' are different 'magnolify.parquet' != 'null'"
+      )
+    )
+  }
+
   test[AvroParquetWithAnnotationsAndOptions](
     List(
       "root.nested 'name' are different 'AvroParquetWithAnnotations' != 'nested'",
@@ -201,6 +230,7 @@ class AvroParquetSuite extends MagnolifySuite {
       "root.nested 'namespace' are different 'magnolify.parquet' != 'null'"
     )
   )
+
   test[AvroParquetWithAnnotationsAndLists](
     List(
       "root.nested 'name' are different 'AvroParquetWithAnnotations' != 'array'",

--- a/parquet/src/test/scala/magnolify/parquet/ParquetTypeSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/ParquetTypeSuite.scala
@@ -102,23 +102,31 @@ class ParquetTypeSuite extends MagnolifySuite {
   test("ParquetDoc") {
     ensureSerializable(ParquetType[ParquetNestedDoc])
     val pf = ParquetField[ParquetNestedDoc]
-
-    assert(pf.fieldDocs("pd") == "nested")
-    assert(pf.fieldDocs("pd.i") == "integers")
-    assert(pf.fieldDocs("pd.s") == "string")
-    assert(pf.fieldDocs("i") == "integers")
     assert(pf.typeDoc.contains("Parquet with doc"))
+
+    val fieldDocs = pf.fieldDocs(CaseMapper.identity)
+    assert(fieldDocs("pd") == "nested")
+    assert(fieldDocs("pd.i") == "integers")
+    assert(fieldDocs("pd.s") == "string")
+    assert(fieldDocs("i") == "integers")
+
+    val upperFieldDocs = pf.fieldDocs(CaseMapper(_.toUpperCase()))
+    assert(upperFieldDocs("PD") == "nested")
+    assert(upperFieldDocs("PD.I") == "integers")
+    assert(upperFieldDocs("PD.S") == "string")
+    assert(upperFieldDocs("I") == "integers")
   }
 
   test("ParquetDocWithNestedList") {
     ensureSerializable(ParquetType[ParquetNestedListDoc])
     val pf = ParquetField[ParquetNestedListDoc]
-
-    assert(pf.fieldDocs("pd") == "nested")
-    assert(pf.fieldDocs("pd.i") == "integers")
-    assert(pf.fieldDocs("pd.s") == "string")
-    assert(pf.fieldDocs("i") == "integers")
     assert(pf.typeDoc.contains("Parquet with doc with nested list"))
+
+    val fieldDocs = pf.fieldDocs(CaseMapper.identity)
+    assert(fieldDocs("pd") == "nested")
+    assert(fieldDocs("pd.i") == "integers")
+    assert(fieldDocs("pd.s") == "string")
+    assert(fieldDocs("i") == "integers")
   }
 
   // Precision = number of digits, so 5 means -99999 to 99999


### PR DESCRIPTION
case mapper was not applied when creating the doc fields.
When generating the `avroSchema` for a `ParquetField`, docs were not found as there is a mismatch between field names.