### PR TITLE
Support proto3 optional

### DIFF
--- a/docs/protobuf.md
+++ b/docs/protobuf.md
@@ -42,8 +42,6 @@ implicit val efEnum = ProtobufField.enum[Color.Type, ColorProto]
 
 Additional `ProtobufField[T]` instances for `Byte`, `Char`, `Short`, and `UnsafeEnum[T]` are available from `import magnolify.protobuf.unsafe._`. These conversions are unsafe due to potential overflow.
 
-By default nullable type `Option[T]` is not supported when `MsgT` is compiled with Protobuf 3 syntax. This is because Protobuf 3 does not offer a way to check if a field was set, and instead returns `0`, `""`, `false`, etc. when it was not. You can enable Protobuf 3 support for `Option[T]` by adding `import magnolify.protobuf.unsafe.Proto3Option._`. However with this, Scala `None`s will become `0/""/false` in Protobuf and come back as `Some(0/""/false)`.
-
 To use a different field case format in target records, add an optional `CaseMapper` argument to `ProtobufType`. The following example maps `firstName` & `lastName` to `first_name` & `last_name`.
 
 ```scala

--- a/protobuf/src/main/scala/magnolify/protobuf/unsafe/package.scala
+++ b/protobuf/src/main/scala/magnolify/protobuf/unsafe/package.scala
@@ -22,10 +22,6 @@ package object unsafe {
   implicit val pfChar: ProtobufField[Char] = ProtobufField.from[Int](_.toChar)(_.toInt)
   implicit val pfShort: ProtobufField[Short] = ProtobufField.from[Int](_.toShort)(_.toInt)
 
-  object Proto3Option {
-    implicit val proto3Option: ProtobufOption = new ProtobufOption.Proto3Option
-  }
-
   implicit def pfUnsafeEnum[T: EnumType]: ProtobufField[UnsafeEnum[T]] =
     ProtobufField
       .from[String](s => Option(s).filter(_.nonEmpty).map(UnsafeEnum.from[T]).orNull)(

--- a/protobuf/src/test/protobuf/Proto3.proto
+++ b/protobuf/src/test/protobuf/Proto3.proto
@@ -14,10 +14,16 @@ message FloatsP3 {
     double d = 2;
 }
 
-message SingularP3 {
+message RequiredP3 {
     bool b = 1;
     string s = 2;
     int32 i = 3;
+}
+
+message NullableP3 {
+    optional bool b = 1;
+    optional string s = 2;
+    optional int32 i = 3;
 }
 
 message RepeatedP3 {
@@ -30,8 +36,9 @@ message NestedP3 {
     bool b = 1;
     string s = 2;
     int32 i = 3;
-    SingularP3 r = 4;
-    repeated SingularP3 l = 5;
+    RequiredP3 r = 4;
+    optional RequiredP3 o = 5;
+    repeated RequiredP3 l = 6;
 }
 
 message CollectionP3 {
@@ -60,9 +67,9 @@ message EnumsP3 {
     JavaEnums j = 1;
     ScalaEnums s = 2; // Enumeration
     ScalaEnums a = 3; // ADT
-    JavaEnums jo = 4;
-    ScalaEnums so = 5; // Enumeration
-    ScalaEnums ao = 6; // ADT
+    optional JavaEnums jo = 4;
+    optional ScalaEnums so = 5; // Enumeration
+    optional ScalaEnums ao = 6; // ADT
     repeated JavaEnums jr = 7;
     repeated ScalaEnums sr = 8; // Enumeration
     repeated ScalaEnums ar = 9; // ADT
@@ -72,9 +79,9 @@ message UnsafeEnumsP3 {
     string j = 1;
     string s = 2;
     string a = 3;
-    string jo = 4;
-    string so = 5;
-    string ao = 6;
+    optional string jo = 4;
+    optional string so = 5;
+    optional string ao = 6;
     repeated string jr = 7;
     repeated string sr = 8;
     repeated string ar = 9;

--- a/refined/src/test/scala/magnolify/refined/RefinedSuite.scala
+++ b/refined/src/test/scala/magnolify/refined/RefinedSuite.scala
@@ -155,27 +155,32 @@ class RefinedSuite extends MagnolifySuite {
   test("protobuf") {
     import magnolify.protobuf._
     import magnolify.protobuf.Proto3._
-    import magnolify.protobuf.unsafe.Proto3Option._
     import magnolify.refined.protobuf._
-    val tpe1 = ensureSerializable(ProtobufType[ProtoRequired, SingularP3])
-    val required = ProtoRequired(true, record.pct, refineV.unsafeFrom(record.uuid.value))
+    val tpe1 = ensureSerializable(ProtobufType[ProtoRequired, RequiredP3])
+    val required = ProtoRequired(
+      true,
+      record.pct,
+      refineV.unsafeFrom(record.uuid.value)
+    )
     assertEquals(tpe1(tpe1(required)), required)
 
-    val tpe2 = ensureSerializable(ProtobufType[ProtoNullable, SingularP3])
-    val nullable =
-      ProtoNullable(Some(true), Some(record.pct), Some(refineV.unsafeFrom(record.url.get.value)))
+    val tpe2 = ensureSerializable(ProtobufType[ProtoNullable, NullableP3])
+    val nullable = ProtoNullable(
+      Some(true),
+      Some(record.pct),
+      Some(refineV.unsafeFrom(record.url.get.value))
+    )
     assertEquals(tpe2(tpe2(nullable)), nullable)
 
     val tpe3 = ensureSerializable(ProtobufType[ProtoRepeated, RepeatedP3])
-    val repeated =
-      ProtoRepeated(
-        List(true),
-        List(record.pct),
-        List(refineV.unsafeFrom("US"), refineV.unsafeFrom("UK"))
-      )
+    val repeated = ProtoRepeated(
+      List(true),
+      List(record.pct),
+      List(refineV.unsafeFrom("US"), refineV.unsafeFrom("UK"))
+    )
     assertEquals(tpe3(tpe3(repeated)), repeated)
 
-    val bad = SingularP3.newBuilder().setB(true).setI(42).setS("foo").build()
+    val bad = NullableP3.newBuilder().setB(true).setI(42).setS("foo").build()
     val msg = """Both predicates of (isValidUrl("foo") || "foo".matches("^$")) failed. """ +
       """Left: Url predicate failed: URI is not absolute """ +
       """Right: Predicate failed: "foo".matches("^$")."""


### PR DESCRIPTION
Since [protobuf 3.15.0](https://github.com/protocolbuffers/protobuf/releases/tag/v3.15.0) (2021-02), `optional` is supported by default in the proto 3 syntax.
Adapt the `ProtobufType` typeclass to take this into account.

As side effect, this removes the need to check for proto 2 syntax.

Fix #814 