### PR TITLE
Remove FunelDerivation alias

### DIFF
--- a/guava/src/main/scala/magnolify/guava/auto/package.scala
+++ b/guava/src/main/scala/magnolify/guava/auto/package.scala
@@ -29,6 +29,4 @@ package object auto extends FunnelImplicits {
   }
 
   implicit def genFunnel[T]: Funnel[T] = macro genFunnelMacro[T]
-
-  val FunnelDerivation = semiauto.FunnelDerivation
 }

--- a/guava/src/test/scala/magnolify/guava/FunnelDerivationSuite.scala
+++ b/guava/src/test/scala/magnolify/guava/FunnelDerivationSuite.scala
@@ -19,6 +19,7 @@ package magnolify.guava
 import com.google.common.hash.Funnel
 import com.google.common.hash.PrimitiveSink
 import magnolify.guava.auto._
+import magnolify.guava.semiauto.FunnelDerivation
 import magnolify.scalacheck.auto._
 import magnolify.scalacheck.TestArbitrary._
 import magnolify.test.ADT._

--- a/refined/src/test/scala/magnolify/refined/RefinedSuite.scala
+++ b/refined/src/test/scala/magnolify/refined/RefinedSuite.scala
@@ -23,6 +23,7 @@ import eu.timepit.refined.boolean._
 import eu.timepit.refined.numeric._
 import eu.timepit.refined.string._
 import magnolify.guava.BytesSink
+import magnolify.guava.semiauto.FunnelDerivation
 import magnolify.test._
 
 object RefinedSuite {


### PR DESCRIPTION
`FunelDerivation` has an alias in the `auto` package, which is not in line with other semi-auto typeclasses.

When both `auto` and `semiauto` are imported, this raises a warning for shadowing.
Force user to import `FunelDerivation` from the `semiauto` package