### PR TITLE
fix typo: achiving -> achieving

### DIFF
--- a/docs/avro.md
+++ b/docs/avro.md
@@ -30,7 +30,7 @@ avroType.schema
 
 Enum-like types map to Avro enums. See [enums.md](https://github.com/spotify/magnolify/tree/master/docs/enums.md) for more details. Additional `AvroField[T]` instances for `Byte`, `Char`, `Short`, and `UnsafeEnum[T]` are available from `import magnolify.avro.unsafe._`. These conversions are unsafe due to potential overflow.
 
-Achiving backward compatibility when adding new fields to the case class: new fields must have a default parameter value in order to generate backward compatible Avro schema `avroType.schema`.
+Achieving backward compatibility when adding new fields to the case class: new fields must have a default parameter value in order to generate backward compatible Avro schema `avroType.schema`.
 
 ```scala
 case class Record(oldField: String, newField: String = "")


### PR DESCRIPTION
I found a typo in reading `avro.md` in docs.

```diff
< Achiving backward compatibility when
> Achieving backward compatibility when
```
