### PR TITLE
Move coverage out of default ci pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,15 +74,7 @@ jobs:
         run: sbt githubWorkflowCheck
 
       - name: Build project
-        if: matrix.scala == '2.13' && matrix.java == 'corretto@11'
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' coverage test coverageAggregate
-
-      - name: Upload coverage report
-        if: matrix.scala == '2.13' && matrix.java == 'corretto@11'
-        run: 'bash <(curl -s https://codecov.io/bash)'
-
-      - name: Build project
-        if: '!(matrix.scala == ''2.13'' && matrix.java == ''corretto@11'' || matrix.scala == ''3'')'
+        if: '!(matrix.scala == ''3'')'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' test
 
       - name: Build project
@@ -269,6 +261,54 @@ jobs:
           apps: scala-steward
 
       - run: scala-steward validate-repo-config .scala-steward.conf
+
+  coverage:
+    name: Test coverage
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.12]
+        java: [corretto@11]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java (corretto@17)
+        id: setup-java-corretto-17
+        if: matrix.java == 'corretto@17'
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 17
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'corretto@17' && steps.setup-java-corretto-17.outputs.cache-hit == 'false'
+        run: sbt +update
+
+      - name: Setup Java (corretto@11)
+        id: setup-java-corretto-11
+        if: matrix.java == 'corretto@11'
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 11
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'corretto@11' && steps.setup-java-corretto-11.outputs.cache-hit == 'false'
+        run: sbt +update
+
+      - name: Build project
+        if: matrix.scala == '2.13' && matrix.java == 'corretto@11'
+        run: sbt '++ ${{ matrix.scala }}' coverage test coverageAggregate
+
+      - name: Upload coverage report
+        if: matrix.scala == '2.13' && matrix.java == 'corretto@11'
+        run: 'bash <(curl -s https://codecov.io/bash)'
 
   avro-legacy:
     name: Test with legacy avro

--- a/build.sbt
+++ b/build.sbt
@@ -122,21 +122,14 @@ ThisBuild / scalaVersion := scalaDefault
 ThisBuild / crossScalaVersions := Seq(scala3, scala213, scala212)
 ThisBuild / githubWorkflowTargetBranches := Seq("main")
 ThisBuild / githubWorkflowJavaVersions := Seq(java17, java11)
+ThisBuild / tlCiHeaderCheck := true
+ThisBuild / tlCiScalafmtCheck := true
+ThisBuild / tlCiMimaBinaryIssueCheck := true
 ThisBuild / githubWorkflowBuild := Seq(
-  WorkflowStep.Sbt(
-    List("coverage", "test", "coverageAggregate"),
-    name = Some("Build project"),
-    cond = Some(coverageCond)
-  ),
-  WorkflowStep.Run(
-    List("bash <(curl -s https://codecov.io/bash)"),
-    name = Some("Upload coverage report"),
-    cond = Some(coverageCond)
-  ),
   WorkflowStep.Sbt(
     List("test"),
     name = Some("Build project"),
-    cond = Some(s"!($coverageCond || $scala3Cond)")
+    cond = Some(s"!($scala3Cond)")
   ),
   WorkflowStep.Sbt(
     scala3Projects.map(p => s"$p/test"),
@@ -145,6 +138,24 @@ ThisBuild / githubWorkflowBuild := Seq(
   )
 )
 ThisBuild / githubWorkflowAddedJobs ++= Seq(
+  WorkflowJob(
+    "coverage",
+    "Test coverage",
+    githubWorkflowJobSetup.value.toList ::: List(
+      WorkflowStep.Sbt(
+        List("coverage", "test", "coverageAggregate"),
+        name = Some("Build project"),
+        cond = Some(coverageCond)
+      ),
+      WorkflowStep.Run(
+        List("bash <(curl -s https://codecov.io/bash)"),
+        name = Some("Upload coverage report"),
+        cond = Some(coverageCond)
+      )
+    ),
+    scalas = List(scalaDefault),
+    javas = List(javaDefault)
+  ),
   WorkflowJob(
     "avro-legacy",
     "Test with legacy avro",


### PR DESCRIPTION
Coverage should not ge in default build pipline as the produced artifact is published directly. Published library MUST not contain instrumented bytecode.