### PR TITLE
Keep using implicit while cross compiling with scala 2

### DIFF
--- a/shared/src/main/scala-3/magnolify/shared/AnnotationTypeMacros.scala
+++ b/shared/src/main/scala-3/magnolify/shared/AnnotationTypeMacros.scala
@@ -55,4 +55,4 @@ object AnnotationTypeMacros:
     '{ AnnotationType[T]($annotations) }
 
 trait AnnotationTypeCompanionMacros:
-  inline given gen[T]: AnnotationType[T] = ${ AnnotationTypeMacros.annotationTypeMacro[T] }
+  inline implicit def gen[T]: AnnotationType[T] = ${ AnnotationTypeMacros.annotationTypeMacro[T] }

--- a/shared/src/main/scala-3/magnolify/shared/EnumTypeMacros.scala
+++ b/shared/src/main/scala-3/magnolify/shared/EnumTypeMacros.scala
@@ -38,10 +38,10 @@ object EnumTypeMacros:
 trait EnumTypeCompanionMacros extends EnumTypeCompanionMacros0
 
 trait EnumTypeCompanionMacros0 extends EnumTypeCompanionMacros1:
-  inline given scalaEnumType[T <: Enumeration#Value](using
+  inline implicit def scalaEnumType[T <: Enumeration#Value](using
     annotations: AnnotationType[T]
   ): EnumType[T] =
     ${ EnumTypeMacros.scalaEnumTypeMacro[T]('annotations) }
 
 trait EnumTypeCompanionMacros1 extends EnumTypeDerivation:
-  inline given gen[T](using Mirror.Of[T]): EnumType[T] = derivedMirror[T]
+  inline implicit def gen[T](using Mirror.Of[T]): EnumType[T] = derivedMirror[T]

--- a/test/src/test/scala/magnolify/shared/EnumTypeSuite.scala
+++ b/test/src/test/scala/magnolify/shared/EnumTypeSuite.scala
@@ -124,7 +124,7 @@ class EnumTypeSuite extends MagnolifySuite {
            |      ]
            |    )
            |
-           |But given instance gen in trait EnumTypeCompanionMacros1 does not match type magnolify.shared.EnumType[Option[magnolify.test.ADT.Color]]
+           |But method gen in trait EnumTypeCompanionMacros1 does not match type magnolify.shared.EnumType[Option[magnolify.test.ADT.Color]]
            |
            |where:    MirroredMonoType  is a type in an anonymous class locally defined in class EnumTypeSuite which is an alias of Option[magnolify.test.ADT.Color]
            |          MirroredMonoType² is a type in trait Mirror with bounds""".stripMargin + " \n" + """|.


### PR DESCRIPTION
While this library cross-builds with scala 2, it is better to keep consistency and only use implicit.