### PR TITLE
Keep scala 3 build but skip publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13, 2.12]
+        scala: [3, 2.13, 2.12]
         java: [corretto@17, corretto@11]
         project: [rootJVM]
         exclude:
+          - scala: 3
+            java: corretto@11
           - scala: 2.12
             java: corretto@11
     runs-on: ${{ matrix.os }}
@@ -147,6 +149,16 @@ jobs:
         if: matrix.java == 'corretto@11' && steps.setup-java-corretto-11.outputs.cache-hit == 'false'
         run: sbt +update
 
+      - name: Download target directories (3, rootJVM)
+        uses: actions/download-artifact@v3
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3-rootJVM
+
+      - name: Inflate target directories (3, rootJVM)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
       - name: Download target directories (2.13, rootJVM)
         uses: actions/download-artifact@v3
         with:
@@ -234,7 +246,7 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: test_3 test_2.13 test_2.12 magnolify-docs_2.13 magnolify_2.13 magnolify_2.12 site_2.13 site_2.12 magnolify_2.13 magnolify_2.12 magnolify_2.13 magnolify_2.12
+          modules-ignore: test_3 test_2.13 test_2.12 magnolify-docs_2.13 magnolify_3 magnolify_2.13 magnolify_2.12 site_2.13 site_2.12 magnolify_3 magnolify_2.13 magnolify_2.12 magnolify_3 magnolify_2.13 magnolify_2.12
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
   validate-steward:

--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,7 @@ val condIsMain = "github.ref == 'refs/heads/main'"
 val condIsTag = "startsWith(github.ref, 'refs/tags/v')"
 
 ThisBuild / scalaVersion := scalaDefault
-ThisBuild / crossScalaVersions := Seq( /*scala3,*/ scala213, scala212) // delay scala3 for 0.8
+ThisBuild / crossScalaVersions := Seq(scala3, scala213, scala212)
 ThisBuild / githubWorkflowTargetBranches := Seq("main")
 ThisBuild / githubWorkflowJavaVersions := Seq(java17, java11)
 ThisBuild / tlJdkRelease := Some(8)
@@ -250,6 +250,8 @@ lazy val keepExistingHeader =
 val commonSettings = Seq(
   // So far most projects do no support scala 3
   crossScalaVersions := Seq(scala213, scala212),
+  // skip scala 3 publishing until ready
+  publish / skip := (publish / skip).value || (scalaVersion.value == scala3),
   scalaVersion := scalaDefault,
   scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((3, _)) =>


### PR DESCRIPTION
With #887, scala 3 artifacts are still published by `+publish`. Change strategy to keep scala 3 build in CI, only skip publishing