### PR TITLE
[shared] Add scala 2.12 CanBuildFrom for Set

### DIFF
--- a/protobuf/src/test/protobuf/Proto2.proto
+++ b/protobuf/src/test/protobuf/Proto2.proto
@@ -45,6 +45,7 @@ message CollectionP2 {
     repeated int32 a = 1;
     repeated int32 l = 2;
     repeated int32 v = 3;
+    repeated int32 s = 4;
 }
 
 message MoreCollectionP2 {

--- a/protobuf/src/test/protobuf/Proto3.proto
+++ b/protobuf/src/test/protobuf/Proto3.proto
@@ -45,6 +45,7 @@ message CollectionP3 {
     repeated int32 a = 1;
     repeated int32 l = 2;
     repeated int32 v = 3;
+    repeated int32 s = 4;
 }
 
 message MoreCollectionP3 {

--- a/shared/src/main/scala-2.12/magnolify/shims/SerializableCanBuildFrom.scala
+++ b/shared/src/main/scala-2.12/magnolify/shims/SerializableCanBuildFrom.scala
@@ -56,7 +56,12 @@ trait SerializableCanBuildFromLowPrio3 extends SerializableCanBuildFromLowPrio4 
     SerializableCanBuildFrom(Stream.newBuilder[A])
 }
 
-trait SerializableCanBuildFromLowPrio4 {
+trait SerializableCanBuildFromLowPrio4 extends SerializableCanBuildFromLowPrio5 {
   implicit def lazyListCBF[A]: SerializableCanBuildFrom[Any, A, LazyList[A]] =
     SerializableCanBuildFrom(LazyList.newBuilder[A])
+}
+
+trait SerializableCanBuildFromLowPrio5 {
+  implicit def setCBF[A]: SerializableCanBuildFrom[Any, A, Set[A]] =
+    SerializableCanBuildFrom(Set.newBuilder[A])
 }

--- a/test/src/test/scala/magnolify/test/Simple.scala
+++ b/test/src/test/scala/magnolify/test/Simple.scala
@@ -58,6 +58,7 @@ object Simple {
       hash = 31 * hash + util.Arrays.hashCode(a)
       hash = 31 * hash + Objects.hashCode(l)
       hash = 31 * hash + Objects.hashCode(v)
+      hash = 31 * hash + Objects.hashCode(s)
       hash
     }
 
@@ -65,7 +66,8 @@ object Simple {
       case that: Collections =>
         Objects.deepEquals(this.a, that.a) &&
         Objects.equals(this.l, that.l) &&
-        Objects.equals(this.v, that.v)
+        Objects.equals(this.v, that.v) &&
+        Objects.equals(this.s, that.s)
       case _ => false
     }
   }

--- a/test/src/test/scala/magnolify/test/Simple.scala
+++ b/test/src/test/scala/magnolify/test/Simple.scala
@@ -51,7 +51,7 @@ object Simple {
     o: Option[Required],
     l: List[Required]
   )
-  case class Collections(a: Array[Int], l: List[Int], v: Vector[Int]) {
+  case class Collections(a: Array[Int], l: List[Int], v: Vector[Int], s: Set[Int]) {
 
     override def hashCode(): Int = {
       var hash = 1


### PR DESCRIPTION
Set could be use as collection in scala 2.13 but not in 2.12 due to a missing serializable can build from factory.