### PR TITLE
[scala-steward] Stay on scala3 LTS line

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -3,6 +3,10 @@ updates.ignore = [
   { groupId = "org.neo4j.driver" } # v5 only supports java 17
 ]
 
+updates.pin  = [
+  { groupId = "org.scala-lang", artifactId="scala3-library", version = "3.3." } # stay on LTS
+]
+
 dependencyOverrides = [
   # version includes revision date. reduce PR frequency
   {


### PR DESCRIPTION
As library, this should stay on the LTS line