### PR TITLE
Add benchmarks for magnolify-parquet vs parquet-avro R/W

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -747,6 +747,7 @@ lazy val jmh: Project = project
     cats % Test,
     datastore % Test,
     guava % Test,
+    parquet % Test,
     protobuf % "test->test",
     scalacheck % Test,
     tensorflow % Test,
@@ -766,7 +767,13 @@ lazy val jmh: Project = project
       "com.google.apis" % "google-api-services-bigquery" % bigqueryVersion % Test,
       "com.google.cloud.datastore" % "datastore-v1-proto-client" % datastoreVersion % Test,
       "org.apache.avro" % "avro" % avroVersion % Test,
-      "org.tensorflow" % "tensorflow-core-api" % tensorflowVersion % Test
+      "org.tensorflow" % "tensorflow-core-api" % tensorflowVersion % Test,
+      "joda-time" % "joda-time" % jodaTimeVersion % Test,
+      "org.apache.parquet" % "parquet-avro" % parquetVersion % Test,
+      "org.apache.parquet" % "parquet-column" % parquetVersion % Test,
+      "org.apache.parquet" % "parquet-hadoop" % parquetVersion % Test,
+      "org.apache.hadoop" % "hadoop-common" % hadoopVersion % Test,
+      "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion % Test
     )
   )
 

--- a/jmh/src/test/scala/magnolify/jmh/MagnolifyBench.scala
+++ b/jmh/src/test/scala/magnolify/jmh/MagnolifyBench.scala
@@ -160,7 +160,8 @@ class ExampleBench {
   private val exampleNested = implicitly[Arbitrary[ExampleNested]].arbitrary(prms, seed).get
   private val example = exampleType.to(exampleNested).build()
   @Benchmark def exampleTo: Example.Builder = exampleType.to(exampleNested)
-  @Benchmark def exampleFrom: ExampleNested = exampleType.from(example.getFeatures.getFeatureMap.asScala.toMap)
+  @Benchmark def exampleFrom: ExampleNested =
+    exampleType.from(example.getFeatures.getFeatureMap.asScala.toMap)
 }
 
 @BenchmarkMode(Array(Mode.AverageTime))
@@ -169,8 +170,10 @@ class ExampleBench {
 class ParquetMagnolifyBench {
   import MagnolifyBench._
 
-  @Benchmark def parquetWrite(state: ParquetStates.ParquetCaseClassWriteState): Unit = state.writer.write(nested)
-  @Benchmark def parquetRead(state: ParquetStates.ParquetCaseClassReadState): Nested = state.reader.read()
+  @Benchmark def parquetWrite(state: ParquetStates.ParquetCaseClassWriteState): Unit =
+    state.writer.write(nested)
+  @Benchmark def parquetRead(state: ParquetStates.ParquetCaseClassReadState): Nested =
+    state.reader.read()
 }
 
 @BenchmarkMode(Array(Mode.AverageTime))
@@ -183,8 +186,10 @@ class ParquetAvroBench {
 
   private val record = AvroType[Nested].to(nested)
 
-  @Benchmark def parquetWrite(state: ParquetStates.ParquetAvroWriteState): Unit = state.writer.write(record)
-  @Benchmark def parquetRead(state: ParquetStates.ParquetAvroReadState): GenericRecord = state.reader.read()
+  @Benchmark def parquetWrite(state: ParquetStates.ParquetAvroWriteState): Unit =
+    state.writer.write(record)
+  @Benchmark def parquetRead(state: ParquetStates.ParquetAvroReadState): GenericRecord =
+    state.reader.read()
 }
 
 object ParquetStates {
@@ -203,7 +208,12 @@ object ParquetStates {
   import org.apache.parquet.column.impl.ColumnWriteStoreV1
 
   @State(Scope.Benchmark)
-  class ReadState[T](schema: MessageType, writeSupport: WriteSupport[T], readSupport: ReadSupport[T], record: T) {
+  class ReadState[T](
+    schema: MessageType,
+    writeSupport: WriteSupport[T],
+    readSupport: ReadSupport[T],
+    record: T
+  ) {
     import org.apache.parquet.hadoop.api.InitContext
 
     var reader: RecordReader[T] = null
@@ -233,7 +243,8 @@ object ParquetStates {
           conf,
           new java.util.HashMap,
           schema,
-          readSupport.init(new InitContext(conf, new java.util.HashMap, schema)))
+          readSupport.init(new InitContext(conf, new java.util.HashMap, schema))
+        )
       ): @nowarn("cat=deprecation")
     }
   }
@@ -260,24 +271,41 @@ object ParquetStates {
 
   // R/W support for Group <-> Case Class Conversion (magnolify-parquet)
   private val parquetType = ParquetType[Nested]
-  class ParquetCaseClassReadState extends ParquetStates.ReadState[Nested](
-    parquetType.schema, parquetType.writeSupport, parquetType.readSupport, nested
-  )
-  class ParquetCaseClassWriteState extends ParquetStates.WriteState[Nested](
-    parquetType.schema, parquetType.writeSupport
-  )
+  class ParquetCaseClassReadState
+      extends ParquetStates.ReadState[Nested](
+        parquetType.schema,
+        parquetType.writeSupport,
+        parquetType.readSupport,
+        nested
+      )
+  class ParquetCaseClassWriteState
+      extends ParquetStates.WriteState[Nested](
+        parquetType.schema,
+        parquetType.writeSupport
+      )
 
   // R/W support for Group <-> Avro Conversion (parquet-avro)
   private val avroType = AvroType[Nested]
-  class ParquetAvroReadState extends ParquetStates.ReadState[GenericRecord](
-    parquetType.schema,
-    new AvroWriteSupport[GenericRecord](parquetType.schema, parquetType.avroSchema, GenericData.get()),
-    new AvroReadSupport[GenericRecord](GenericData.get()), avroType.to(nested)
-  )
-  class ParquetAvroWriteState extends ParquetStates.WriteState[GenericRecord](
-    parquetType.schema,
-    new AvroWriteSupport[GenericRecord](parquetType.schema, parquetType.avroSchema, GenericData.get())
-  )
+  class ParquetAvroReadState
+      extends ParquetStates.ReadState[GenericRecord](
+        parquetType.schema,
+        new AvroWriteSupport[GenericRecord](
+          parquetType.schema,
+          parquetType.avroSchema,
+          GenericData.get()
+        ),
+        new AvroReadSupport[GenericRecord](GenericData.get()),
+        avroType.to(nested)
+      )
+  class ParquetAvroWriteState
+      extends ParquetStates.WriteState[GenericRecord](
+        parquetType.schema,
+        new AvroWriteSupport[GenericRecord](
+          parquetType.schema,
+          parquetType.avroSchema,
+          GenericData.get()
+        )
+      )
 }
 
 // Collections are not supported

--- a/jmh/src/test/scala/magnolify/jmh/ParquetInMemoryPageStore.scala
+++ b/jmh/src/test/scala/magnolify/jmh/ParquetInMemoryPageStore.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package magnolify.jmh
 
 import org.apache.parquet.bytes.{ByteBufferReleaser, BytesInput, HeapByteBufferAllocator}

--- a/jmh/src/test/scala/magnolify/jmh/ParquetInMemoryPageStore.scala
+++ b/jmh/src/test/scala/magnolify/jmh/ParquetInMemoryPageStore.scala
@@ -16,10 +16,12 @@ class ParquetInMemoryPageStore(rowCount: Long) extends PageReadStore with PageWr
   lazy val readers = new mutable.HashMap[ColumnDescriptor, ParquetInMemoryReader]()
 
   override def getPageReader(path: ColumnDescriptor): PageReader =
-    readers.getOrElseUpdate(path, {
-      val writer = writers(path)
-      new ParquetInMemoryReader(writer.numValues, writer.pages.toList, writer.dictionaryPage)
-    })
+    readers.getOrElseUpdate(
+      path, {
+        val writer = writers(path)
+        new ParquetInMemoryReader(writer.numValues, writer.pages.toList, writer.dictionaryPage)
+      }
+    )
 
   override def getPageWriter(path: ColumnDescriptor): PageWriter =
     writers.getOrElseUpdate(path, new ParquetInMemoryWriter())
@@ -27,7 +29,8 @@ class ParquetInMemoryPageStore(rowCount: Long) extends PageReadStore with PageWr
   override def getRowCount: Long = rowCount
 }
 
-class ParquetInMemoryReader(valueCount: Long, pages: List[DataPage], dictionaryPage: DictionaryPage) extends PageReader {
+class ParquetInMemoryReader(valueCount: Long, pages: List[DataPage], dictionaryPage: DictionaryPage)
+    extends PageReader {
   lazy val pagesIt = pages.iterator
 
   override def readDictionaryPage(): DictionaryPage = dictionaryPage
@@ -42,37 +45,70 @@ class ParquetInMemoryWriter extends PageWriter {
   val pages = new mutable.ListBuffer[DataPage]()
   var dictionaryPage: DictionaryPage = null
 
-  override def writePage(bytesInput: BytesInput, valueCount: Int, statistics: Statistics[_], rlEncoding: Encoding, dlEncoding: Encoding, valuesEncoding: Encoding): Unit = {
+  override def writePage(
+    bytesInput: BytesInput,
+    valueCount: Int,
+    statistics: Statistics[_],
+    rlEncoding: Encoding,
+    dlEncoding: Encoding,
+    valuesEncoding: Encoding
+  ): Unit =
     writePage(bytesInput, valueCount, 1, statistics, rlEncoding, dlEncoding, valuesEncoding)
-  }
 
-  override def writePage(bytesInput: BytesInput, valueCount: Int, rowCount: Int, statistics: Statistics[_], sizeStatistics: SizeStatistics, rlEncoding: Encoding, dlEncoding: Encoding, valuesEncoding: Encoding): Unit = {
+  override def writePage(
+    bytesInput: BytesInput,
+    valueCount: Int,
+    rowCount: Int,
+    statistics: Statistics[_],
+    sizeStatistics: SizeStatistics,
+    rlEncoding: Encoding,
+    dlEncoding: Encoding,
+    valuesEncoding: Encoding
+  ): Unit =
     writePage(bytesInput, valueCount, rowCount, statistics, rlEncoding, dlEncoding, valuesEncoding)
-  }
 
-  override def writePage(bytesInput: BytesInput, valueCount: Int, rowCount: Int, statistics: Statistics[_], rlEncoding: Encoding, dlEncoding: Encoding, valuesEncoding: Encoding): Unit = {
-    pages.addOne(new DataPageV1(
-      bytesInput.copy(new ByteBufferReleaser(new HeapByteBufferAllocator)),
-      valueCount,
-      bytesInput.size().toInt,
-      statistics,
-      rlEncoding,
-      dlEncoding,
-      valuesEncoding))
+  override def writePage(
+    bytesInput: BytesInput,
+    valueCount: Int,
+    rowCount: Int,
+    statistics: Statistics[_],
+    rlEncoding: Encoding,
+    dlEncoding: Encoding,
+    valuesEncoding: Encoding
+  ): Unit = {
+    pages.addOne(
+      new DataPageV1(
+        bytesInput.copy(new ByteBufferReleaser(new HeapByteBufferAllocator)),
+        valueCount,
+        bytesInput.size().toInt,
+        statistics,
+        rlEncoding,
+        dlEncoding,
+        valuesEncoding
+      )
+    )
     memSize += bytesInput.size()
     numRows += rowCount
     numValues += valueCount
   }
 
-  override def writePageV2(rowCount: Int, nullCount: Int, valueCount: Int, repetitionLevels: BytesInput, definitionLevels: BytesInput, dataEncoding: Encoding, data: BytesInput, statistics: Statistics[_]): Unit = ???
+  override def writePageV2(
+    rowCount: Int,
+    nullCount: Int,
+    valueCount: Int,
+    repetitionLevels: BytesInput,
+    definitionLevels: BytesInput,
+    dataEncoding: Encoding,
+    data: BytesInput,
+    statistics: Statistics[_]
+  ): Unit = ???
 
   override def getMemSize: Long = memSize
 
   override def allocatedSize(): Long = memSize
 
-  override def writeDictionaryPage(dictionaryPage: DictionaryPage): Unit = {
+  override def writeDictionaryPage(dictionaryPage: DictionaryPage): Unit =
     this.dictionaryPage = dictionaryPage
-  }
 
   override def memUsageString(prefix: String): String = s"$prefix $memSize bytes"
 }

--- a/jmh/src/test/scala/magnolify/jmh/ParquetInMemoryPageStore.scala
+++ b/jmh/src/test/scala/magnolify/jmh/ParquetInMemoryPageStore.scala
@@ -1,0 +1,78 @@
+package magnolify.jmh
+
+import org.apache.parquet.bytes.{ByteBufferReleaser, BytesInput, HeapByteBufferAllocator}
+import org.apache.parquet.column.{ColumnDescriptor, Encoding}
+import org.apache.parquet.column.page._
+import org.apache.parquet.column.statistics._
+
+import scala.collection.mutable
+
+/**
+ * An in-memory Parquet page store modeled after parquet-java's MemPageStore, used to benchmark
+ * ParquetType conversion between Parquet Groups and Scala case classes
+ */
+class ParquetInMemoryPageStore(rowCount: Long) extends PageReadStore with PageWriteStore {
+  lazy val writers = new mutable.HashMap[ColumnDescriptor, ParquetInMemoryWriter]()
+  lazy val readers = new mutable.HashMap[ColumnDescriptor, ParquetInMemoryReader]()
+
+  override def getPageReader(path: ColumnDescriptor): PageReader =
+    readers.getOrElseUpdate(path, {
+      val writer = writers(path)
+      new ParquetInMemoryReader(writer.numValues, writer.pages.toList, writer.dictionaryPage)
+    })
+
+  override def getPageWriter(path: ColumnDescriptor): PageWriter =
+    writers.getOrElseUpdate(path, new ParquetInMemoryWriter())
+
+  override def getRowCount: Long = rowCount
+}
+
+class ParquetInMemoryReader(valueCount: Long, pages: List[DataPage], dictionaryPage: DictionaryPage) extends PageReader {
+  lazy val pagesIt = pages.iterator
+
+  override def readDictionaryPage(): DictionaryPage = dictionaryPage
+  override def getTotalValueCount: Long = valueCount
+  override def readPage(): DataPage = pagesIt.next()
+}
+
+class ParquetInMemoryWriter extends PageWriter {
+  var numRows = 0
+  var numValues: Long = 0
+  var memSize: Long = 0
+  val pages = new mutable.ListBuffer[DataPage]()
+  var dictionaryPage: DictionaryPage = null
+
+  override def writePage(bytesInput: BytesInput, valueCount: Int, statistics: Statistics[_], rlEncoding: Encoding, dlEncoding: Encoding, valuesEncoding: Encoding): Unit = {
+    writePage(bytesInput, valueCount, 1, statistics, rlEncoding, dlEncoding, valuesEncoding)
+  }
+
+  override def writePage(bytesInput: BytesInput, valueCount: Int, rowCount: Int, statistics: Statistics[_], sizeStatistics: SizeStatistics, rlEncoding: Encoding, dlEncoding: Encoding, valuesEncoding: Encoding): Unit = {
+    writePage(bytesInput, valueCount, rowCount, statistics, rlEncoding, dlEncoding, valuesEncoding)
+  }
+
+  override def writePage(bytesInput: BytesInput, valueCount: Int, rowCount: Int, statistics: Statistics[_], rlEncoding: Encoding, dlEncoding: Encoding, valuesEncoding: Encoding): Unit = {
+    pages.addOne(new DataPageV1(
+      bytesInput.copy(new ByteBufferReleaser(new HeapByteBufferAllocator)),
+      valueCount,
+      bytesInput.size().toInt,
+      statistics,
+      rlEncoding,
+      dlEncoding,
+      valuesEncoding))
+    memSize += bytesInput.size()
+    numRows += rowCount
+    numValues += valueCount
+  }
+
+  override def writePageV2(rowCount: Int, nullCount: Int, valueCount: Int, repetitionLevels: BytesInput, definitionLevels: BytesInput, dataEncoding: Encoding, data: BytesInput, statistics: Statistics[_]): Unit = ???
+
+  override def getMemSize: Long = memSize
+
+  override def allocatedSize(): Long = memSize
+
+  override def writeDictionaryPage(dictionaryPage: DictionaryPage): Unit = {
+    this.dictionaryPage = dictionaryPage
+  }
+
+  override def memUsageString(prefix: String): String = s"$prefix $memSize bytes"
+}


### PR DESCRIPTION
Adds benchmarks for Parquet read/write performance, for both magnolify-parquet and parquet-avro (although we don't own parquet-avro, it's helpful to compare against IMO).

Parquet is a little tricky in that it doesn't have a granular "write/read a single record to/from a file" operation due to its complex file structure/encodings. This benchmark sets up an in-memory page store that can can read or write Parquet "groups", which are Parquet's internal record structure. Read/write is invoked with a record type `T` and a matching `RecordConverter[T]`, which converts either case classes (magnolify-parquet) or Avro records (parquet-avro) into Parquet groups. Thus, what we're benchmarking here is Group-to-record and record-to-Group conversion, which is the core functionality of magnolify-parquet 👍 

Results:

```
[info] Benchmark                           Mode  Cnt      Score     Error  Units
[info] ParquetAvroBench.parquetRead        avgt   10  14274.174 ± 414.389  ns/op
[info] ParquetAvroBench.parquetWrite       avgt   10  21282.044 ± 409.851  ns/op
[info] ParquetMagnolifyBench.parquetRead   avgt   10  11393.528 ± 211.746  ns/op
[info] ParquetMagnolifyBench.parquetWrite  avgt   10  13282.019 ± 180.685  ns/op
```