### PR TITLE
Tighten schema compatibility checks for repeated types

### DIFF
--- a/parquet/src/main/scala/magnolify/parquet/Schema.scala
+++ b/parquet/src/main/scala/magnolify/parquet/Schema.scala
@@ -99,6 +99,9 @@ private object Schema {
     def listFields(gt: GroupType) =
       s"[${gt.getFields.asScala.map(f => s"${f.getName}: ${f.getRepetition}").mkString(",")}]"
 
+    def isRepeatedType(lta: LogicalTypeAnnotation): Boolean =
+      lta == LogicalTypeAnnotation.listType() || lta == LogicalTypeAnnotation.mapType()
+
     def isRepetitionBackwardCompatible(w: Type, r: Type) =
       (w.getRepetition, r.getRepetition) match {
         case (Repetition.REQUIRED, Repetition.OPTIONAL) => true
@@ -122,17 +125,27 @@ private object Schema {
             val wf = wg.getType(rf.getName)
             checkCompatibility(wf, rf)
           } else {
-            rf.getRepetition match {
-              case Repetition.OPTIONAL =>
-                logger.warn(
-                  s"Requested field `${rf.getName}: ${rf.getRepetition}` is not present in written file schema " +
-                    s"and will be evaluated as `Option.empty`. Available fields are: ${listFields(wg)}"
-                )
-              case _ =>
-                throw new InvalidRecordException(
-                  s"Requested field `${rf.getName}: ${rf.getRepetition}` is not present in written file schema. " +
-                    s"Available fields are: ${listFields(wg)}"
-                )
+            // Check if parent is a grouped list type; the child elements must match exactly,
+            // otherwise reader and writer schema are using different list encodings
+            if (Option(rg.getLogicalTypeAnnotation).exists(isRepeatedType)) {
+              throw new InvalidRecordException(
+                s"Requested field `${rf.getName}: ${rf.getRepetition}` is not present in written file schema. " +
+                  s"Writer schema may be using a different list encoding; see https://spotify.github.io/magnolify/parquet.html#list-encodings."
+              )
+            } else if (
+              rf.getRepetition == Repetition.OPTIONAL ||
+              (rf.isPrimitive && rf.getRepetition == Repetition.REPEATED) ||
+              (!rf.isPrimitive && Option(rf.getLogicalTypeAnnotation).exists(isRepeatedType))
+            ) {
+              logger.warn(
+                s"Requested field `${rf.getName}: ${rf.getRepetition}` is not present in written file schema " +
+                  s"and will be evaluated as empty. Available fields are: ${listFields(wg)}"
+              )
+            } else {
+              throw new InvalidRecordException(
+                s"Requested field `${rf.getName}: ${rf.getRepetition}` is not present in written file schema. " +
+                  s"Available fields are: ${listFields(wg)}"
+              )
             }
           }
         }

--- a/parquet/src/main/scala/magnolify/parquet/Schema.scala
+++ b/parquet/src/main/scala/magnolify/parquet/Schema.scala
@@ -122,21 +122,17 @@ private object Schema {
             val wf = wg.getType(rf.getName)
             checkCompatibility(wf, rf)
           } else {
-            (
-              rf.getLogicalTypeAnnotation != LogicalTypeAnnotation.listType(),
-              rf.getRepetition
-            ) match {
-              case (true, Repetition.REQUIRED) =>
-                throw new InvalidRecordException(
-                  s"Requested field `${rf.getName}: ${rf.getRepetition}` is not present in written file schema. " +
-                    s"Available fields are: ${listFields(wg)}"
-                )
-              case (true, Repetition.OPTIONAL) =>
+            rf.getRepetition match {
+              case Repetition.OPTIONAL =>
                 logger.warn(
                   s"Requested field `${rf.getName}: ${rf.getRepetition}` is not present in written file schema " +
                     s"and will be evaluated as `Option.empty`. Available fields are: ${listFields(wg)}"
                 )
               case _ =>
+                throw new InvalidRecordException(
+                  s"Requested field `${rf.getName}: ${rf.getRepetition}` is not present in written file schema. " +
+                    s"Available fields are: ${listFields(wg)}"
+                )
             }
           }
         }

--- a/parquet/src/test/scala/magnolify/parquet/ListCompatibilitySuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/ListCompatibilitySuite.scala
@@ -23,12 +23,13 @@ import org.apache.parquet.conf.{HadoopParquetConfiguration, ParquetConfiguration
 import org.apache.parquet.hadoop.ParquetWriter
 import org.apache.parquet.hadoop.api.WriteSupport
 import org.apache.parquet.hadoop.api.WriteSupport.WriteContext
-import org.apache.parquet.io.{LocalInputFile, LocalOutputFile}
+import org.apache.parquet.io.{InvalidRecordException, LocalInputFile, LocalOutputFile}
 import org.apache.parquet.io.api.RecordConsumer
 import org.apache.parquet.schema.{MessageType, MessageTypeParser}
 
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
+import scala.util.{Failure, Success, Try}
 
 case class RecordWithListPrimitive(listField: List[Int])
 
@@ -46,6 +47,10 @@ class ListCompatibilitySuite extends MagnolifySuite {
     (1 to 10).map(i => RecordWithListNested((0 until i).map(Element).toList))
 
   test("1-level list encoding with primitive list type") {
+    implicit val typeclass = ParquetType[RecordWithListPrimitive](new MagnolifyParquetProperties {
+      override def writeArrayEncoding: ArrayEncoding = Ungrouped
+    })
+
     val schema = s"""
      |message RecordWith1LevelListPrimitive {
      |  repeated int32 listField (INTEGER(32,true));
@@ -64,10 +69,14 @@ class ListCompatibilitySuite extends MagnolifySuite {
 
         rc.endMessage()
       }
-    )(typeclass = ParquetType[RecordWithListPrimitive])
+    )
   }
 
   test("2-level list encoding with primitive list type") {
+    implicit val typeclass = ParquetType[RecordWithListNested](new MagnolifyParquetProperties {
+      override def writeArrayEncoding: ArrayEncoding = ThreeLevelArray
+    })
+
     val schema = s"""
                     |message RecordWith2LevelListNested {
                     |  required group $ListField (LIST) {
@@ -104,13 +113,11 @@ class ListCompatibilitySuite extends MagnolifySuite {
 
         rc.endMessage()
       }
-    )(typeclass = ParquetType[RecordWithListNested](new MagnolifyParquetProperties {
-      override def writeArrayEncoding: ArrayEncoding = ThreeLevelArray
-    }))
+    )
   }
 
   test("3-Level list encoding with primitive list type") {
-    val typeClass = ParquetType[RecordWithListPrimitive](new MagnolifyParquetProperties {
+    implicit val typeClass = ParquetType[RecordWithListPrimitive](new MagnolifyParquetProperties {
       override def writeArrayEncoding: ArrayEncoding = ThreeLevelList
     })
 
@@ -154,11 +161,108 @@ class ListCompatibilitySuite extends MagnolifySuite {
 
         rc.endMessage()
       }
-    )(typeClass)
+    )
+  }
+
+  test("3-Level writer schema should fail to be read by 2-level reader schema") {
+    val typeClassList = ParquetType[RecordWithListPrimitive](new MagnolifyParquetProperties {
+      override def writeArrayEncoding: ArrayEncoding = ThreeLevelList
+    })
+
+    val typeClassArray = ParquetType[RecordWithListPrimitive](new MagnolifyParquetProperties {
+      override def writeArrayEncoding: ArrayEncoding = ThreeLevelArray
+    })
+
+    Try {
+      roundtripParquet[RecordWithListPrimitive](
+        writeSchema = typeClassList.schema,
+        records = recordsWithListPrimitive,
+        writeFn = { case (record, rc) =>
+          rc.startMessage()
+
+          rc.startField(ListField, 0)
+          rc.startGroup()
+
+          /** Reference: [[org.apache.parquet.avro.AvroWriteSupport#ThreeLevelListWriter]] */
+          rc.startField("list", 0)
+          record.listField.foreach { elem =>
+            rc.startGroup()
+
+            rc.startField("element", 0)
+            rc.addInteger(elem)
+            rc.endField("element", 0)
+
+            rc.endGroup()
+          }
+
+          rc.endField("list", 0)
+          rc.endGroup()
+          rc.endField(ListField, 0)
+
+          rc.endMessage()
+        }
+      )(typeClassList, typeClassArray)
+    } match {
+      case Failure(_: InvalidRecordException) => // success
+      case Failure(e)                         =>
+        fail(
+          s"Expected mismatched list encoding types to throw InvalidRecordException, but caught error $e"
+        )
+      case Success(_) =>
+        fail(s"Expected mismatched list encoding types to throw InvalidRecordException")
+    }
+  }
+
+  test("2-Level writer schema should fail to be read by 3-level reader schema") {
+    val typeClassList = ParquetType[RecordWithListNested](new MagnolifyParquetProperties {
+      override def writeArrayEncoding: ArrayEncoding = ThreeLevelList
+    })
+
+    val typeClassArray = ParquetType[RecordWithListNested](new MagnolifyParquetProperties {
+      override def writeArrayEncoding: ArrayEncoding = ThreeLevelArray
+    })
+
+    Try {
+      roundtripParquet[RecordWithListNested](
+        writeSchema = typeClassArray.schema,
+        records = recordsWithListNested,
+        writeFn = { case (record, rc) =>
+          rc.startMessage()
+
+          rc.startField(ListField, 0)
+          rc.startGroup()
+
+          rc.startField("array", 0)
+          record.listField.foreach { elem =>
+            rc.startGroup()
+
+            rc.startField("i", 0)
+            rc.addInteger(elem.i)
+            rc.endField("i", 0)
+
+            rc.endGroup()
+          }
+          rc.endField("array", 0)
+
+          rc.endGroup()
+          rc.endField(ListField, 0)
+
+          rc.endMessage()
+        }
+      )(typeClassArray, typeClassList)
+    } match {
+      case Failure(_: InvalidRecordException) => // success
+      case Failure(e)                         =>
+        fail(
+          s"Expected mismatched list encoding types to throw InvalidRecordException, but caught error $e"
+        )
+      case Success(_) =>
+        fail(s"Expected mismatched list encoding types to throw InvalidRecordException")
+    }
   }
 
   test("3-Level list encoding with nested list type") {
-    val typeClass = ParquetType[RecordWithListNested](new MagnolifyParquetProperties {
+    implicit val typeClass = ParquetType[RecordWithListNested](new MagnolifyParquetProperties {
       override def writeArrayEncoding: ArrayEncoding = ThreeLevelList
     })
 
@@ -209,7 +313,7 @@ class ListCompatibilitySuite extends MagnolifySuite {
 
         rc.endMessage()
       }
-    )(typeClass)
+    )
   }
 
   class LocalWriteBuilder[T](file: LocalOutputFile, writeSupport: WriteSupport[T])
@@ -222,7 +326,7 @@ class ListCompatibilitySuite extends MagnolifySuite {
     writeSchema: MessageType,
     records: Seq[T],
     writeFn: (T, RecordConsumer) => Unit
-  )(typeclass: ParquetType[T]): Unit = {
+  )(implicit writerTypeclass: ParquetType[T], readerTypeclass: ParquetType[T]): Unit = {
     // Write files manually using provided writer fn
     val manuallyWrittenRecords =
       Files.createTempFile(s"parquet-list-compat-manual-${writeSchema.getName}", ".parquet").toFile
@@ -265,7 +369,7 @@ class ListCompatibilitySuite extends MagnolifySuite {
       magnolifyWrittenRecords.delete() // creating a Path creates the file
       magnolifyWrittenRecords.deleteOnExit()
 
-      val writer = typeclass
+      val writer = writerTypeclass
         .writeBuilder(new LocalOutputFile(magnolifyWrittenRecords.toPath))
         .build()
 
@@ -275,7 +379,7 @@ class ListCompatibilitySuite extends MagnolifySuite {
 
     // Read using typeclass
     val readManuallyWrittenRecords = {
-      val reader = typeclass
+      val reader = readerTypeclass
         .readBuilder(new LocalInputFile(manuallyWrittenRecords.toPath))
         .build()
 
@@ -285,7 +389,7 @@ class ListCompatibilitySuite extends MagnolifySuite {
     }
 
     val readMagnolifyWrittenRecords = {
-      val reader = typeclass
+      val reader = readerTypeclass
         .readBuilder(new LocalInputFile(magnolifyWrittenRecords.toPath))
         .build()
 

--- a/parquet/src/test/scala/magnolify/parquet/SchemaEvolutionSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/SchemaEvolutionSuite.scala
@@ -22,7 +22,6 @@ import magnolify.test._
 import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
 import org.apache.avro.{JsonProperties, Schema => AvroSchema}
 import org.apache.hadoop.conf.Configuration
-import org.apache.parquet.io.InvalidRecordException
 import org.apache.parquet.avro.{
   AvroParquetReader,
   AvroParquetWriter,
@@ -391,10 +390,7 @@ class SchemaEvolutionSuite extends MagnolifySuite {
   }
 
   test("Scala V1 => Scala V2") {
-    // V2 adds aliases (REPEATED) which is not present in V1
-    intercept[InvalidRecordException] {
-      readScala[User2](scalaBytes1)
-    }
+    assertEquals(readScala[User2](scalaBytes1), scala1as2)
   }
 
   test("Scala V2 => Scala V1") {
@@ -415,10 +411,7 @@ class SchemaEvolutionSuite extends MagnolifySuite {
 
   test("Scala Compat V1 => Scala Compat V2") {
     import magnolify.parquet.ParquetArray.AvroCompat._
-    // In AvroCompat mode, aliases is a REQUIRED LIST group — not a valid schema evolution addition
-    intercept[InvalidRecordException] {
-      readScala[User2](scalaCompatBytes1)
-    }
+    assertEquals(readScala[User2](scalaCompatBytes1), scala1as2)
   }
 
   test("Scala Compat V2 => Scala Compat V1") {
@@ -440,10 +433,7 @@ class SchemaEvolutionSuite extends MagnolifySuite {
 
   test("Avro V1 => Scala V2") {
     import magnolify.parquet.ParquetArray.AvroCompat._
-    // In AvroCompat mode, aliases is a REQUIRED LIST group — not a valid schema evolution addition
-    intercept[InvalidRecordException] {
-      readScala[User2](avroBytes1)
-    }
+    assertEquals(readScala[User2](avroBytes1), scala1as2)
   }
 
   test("Avro V2 => Scala V1") {

--- a/parquet/src/test/scala/magnolify/parquet/SchemaEvolutionSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/SchemaEvolutionSuite.scala
@@ -22,6 +22,7 @@ import magnolify.test._
 import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
 import org.apache.avro.{JsonProperties, Schema => AvroSchema}
 import org.apache.hadoop.conf.Configuration
+import org.apache.parquet.io.InvalidRecordException
 import org.apache.parquet.avro.{
   AvroParquetReader,
   AvroParquetWriter,
@@ -390,7 +391,10 @@ class SchemaEvolutionSuite extends MagnolifySuite {
   }
 
   test("Scala V1 => Scala V2") {
-    assertEquals(readScala[User2](scalaBytes1), scala1as2)
+    // V2 adds aliases (REPEATED) which is not present in V1
+    intercept[InvalidRecordException] {
+      readScala[User2](scalaBytes1)
+    }
   }
 
   test("Scala V2 => Scala V1") {
@@ -411,7 +415,10 @@ class SchemaEvolutionSuite extends MagnolifySuite {
 
   test("Scala Compat V1 => Scala Compat V2") {
     import magnolify.parquet.ParquetArray.AvroCompat._
-    assertEquals(readScala[User2](scalaCompatBytes1), scala1as2)
+    // In AvroCompat mode, aliases is a REQUIRED LIST group — not a valid schema evolution addition
+    intercept[InvalidRecordException] {
+      readScala[User2](scalaCompatBytes1)
+    }
   }
 
   test("Scala Compat V2 => Scala Compat V1") {
@@ -433,7 +440,10 @@ class SchemaEvolutionSuite extends MagnolifySuite {
 
   test("Avro V1 => Scala V2") {
     import magnolify.parquet.ParquetArray.AvroCompat._
-    assertEquals(readScala[User2](avroBytes1), scala1as2)
+    // In AvroCompat mode, aliases is a REQUIRED LIST group — not a valid schema evolution addition
+    intercept[InvalidRecordException] {
+      readScala[User2](avroBytes1)
+    }
   }
 
   test("Avro V2 => Scala V1") {

--- a/parquet/src/test/scala/magnolify/parquet/SchemaSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/SchemaSuite.scala
@@ -43,10 +43,34 @@ class SchemaSuite extends MagnolifySuite {
       |}""".stripMargin
   )
 
+  private val threeLevelOptionalListSchema = MessageTypeParser.parseMessageType(
+    """message Record {
+      |  required group nestedGroup {
+      |    optional group listField (LIST) {
+      |      repeated group list {
+      |        required int32 element (INTEGER(32,true));
+      |      }
+      |    }
+      |  }
+      |}""".stripMargin
+  )
+
   private val threeLevelArraySchema = MessageTypeParser.parseMessageType(
     """message Record {
       |  required group nestedGroup {
       |    required group listField (LIST) {
+      |      repeated group array {
+      |        required int32 element (INTEGER(32,true));
+      |      }
+      |    }
+      |  }
+      |}""".stripMargin
+  )
+
+  private val threeLevelOptionalArraySchema = MessageTypeParser.parseMessageType(
+    """message Record {
+      |  required group nestedGroup {
+      |    optional group listField (LIST) {
       |      repeated group array {
       |        required int32 element (INTEGER(32,true));
       |      }
@@ -128,6 +152,14 @@ class SchemaSuite extends MagnolifySuite {
       Schema.checkCompatibility(schemaNoListFields, threeLevelArraySchema)
     }
     assert(e.getMessage.contains("is not present in written file schema"))
+  }
+
+  test("checkCompatibility: reader with 3 level optional list field not in writer is compatible") {
+    Schema.checkCompatibility(schemaNoListFields, threeLevelOptionalListSchema)
+  }
+
+  test("checkCompatibility: reader with 3 level optional array field not in writer is compatible") {
+    Schema.checkCompatibility(schemaNoListFields, threeLevelOptionalArraySchema)
   }
 
   test("checkCompatibility: reader with map field not in writer is not compatible") {

--- a/parquet/src/test/scala/magnolify/parquet/SchemaSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/SchemaSuite.scala
@@ -16,11 +16,32 @@
 
 package magnolify.parquet
 
+import magnolify.parquet.ArrayEncoding._
 import magnolify.test.MagnolifySuite
 import org.apache.parquet.io.InvalidRecordException
 import org.apache.parquet.schema.MessageTypeParser
 
+object SchemaSuite {
+  case class RecordWithPrimitiveList(l: List[Int])
+
+  case class Nested(i: Int)
+  case class RecordWithNestedList(n: Nested)
+
+  val PtUngroupedList = ParquetType[RecordWithListPrimitive](new MagnolifyParquetProperties {
+    override def writeArrayEncoding: ArrayEncoding = Ungrouped
+  })
+
+  val PtThreeLevelListEnc = ParquetType[RecordWithListPrimitive](new MagnolifyParquetProperties {
+    override def writeArrayEncoding: ArrayEncoding = ThreeLevelList
+  })
+
+  val PtThreeLevelArrayEnc = ParquetType[RecordWithListPrimitive](new MagnolifyParquetProperties {
+    override def writeArrayEncoding: ArrayEncoding = ThreeLevelArray
+  })
+}
+
 class SchemaSuite extends MagnolifySuite {
+  import SchemaSuite._
 
   private val schemaNoListFields = MessageTypeParser.parseMessageType(
     """message Record {
@@ -31,149 +52,80 @@ class SchemaSuite extends MagnolifySuite {
       |}""".stripMargin
   )
 
-  private val threeLevelListSchema = MessageTypeParser.parseMessageType(
-    """message Record {
-      |  required group nestedGroup {
-      |    required group listField (LIST) {
-      |      repeated group list {
-      |        required int32 element (INTEGER(32,true));
-      |      }
-      |    }
-      |  }
-      |}""".stripMargin
-  )
-
-  private val threeLevelOptionalListSchema = MessageTypeParser.parseMessageType(
-    """message Record {
-      |  required group nestedGroup {
-      |    optional group listField (LIST) {
-      |      repeated group list {
-      |        required int32 element (INTEGER(32,true));
-      |      }
-      |    }
-      |  }
-      |}""".stripMargin
-  )
-
-  private val threeLevelArraySchema = MessageTypeParser.parseMessageType(
-    """message Record {
-      |  required group nestedGroup {
-      |    required group listField (LIST) {
-      |      repeated group array {
-      |        required int32 element (INTEGER(32,true));
-      |      }
-      |    }
-      |  }
-      |}""".stripMargin
-  )
-
-  private val threeLevelOptionalArraySchema = MessageTypeParser.parseMessageType(
-    """message Record {
-      |  required group nestedGroup {
-      |    optional group listField (LIST) {
-      |      repeated group array {
-      |        required int32 element (INTEGER(32,true));
-      |      }
-      |    }
-      |  }
-      |}""".stripMargin
-  )
-
-  private val ungroupedSchema = MessageTypeParser.parseMessageType(
-    """message Record {
-      |  required group nestedGroup {
-      |    repeated int32 listField (INTEGER(32,true));
-      |  }
-      |}""".stripMargin
-  )
-
-  private val primitiveSchema = MessageTypeParser.parseMessageType(
-    """message Record {
-      |  required int32 listField (INTEGER(32,true));
-      |}""".stripMargin
-  )
-
-  private val mapSchema = MessageTypeParser.parseMessageType(
-    """message Record {
-      |  required group my_map (MAP) {
-      |    repeated group key_value {
-      |      required binary key (STRING);
-      |      optional int32 value;
-      |    }
-      |  }
-      |}""".stripMargin
-  )
-
   test("checkCompatibility: 3-level list writer compatible with 3-level list reader") {
-    Schema.checkCompatibility(threeLevelListSchema, threeLevelListSchema)
+    Schema.checkCompatibility(PtThreeLevelListEnc.schema, PtThreeLevelListEnc.schema)
   }
 
   test("checkCompatibility: 3-level array writer compatible with 3-level array reader") {
-    Schema.checkCompatibility(threeLevelArraySchema, threeLevelArraySchema)
+    Schema.checkCompatibility(PtThreeLevelArrayEnc.schema, PtThreeLevelArrayEnc.schema)
   }
 
   test("checkCompatibility: 3-level list writer incompatible with 3-level array reader") {
     intercept[InvalidRecordException] {
-      Schema.checkCompatibility(threeLevelListSchema, threeLevelArraySchema)
+      Schema.checkCompatibility(PtThreeLevelListEnc.schema, PtThreeLevelArrayEnc.schema)
+    }
+  }
+
+  test("checkCompatibility: 3-level list writer incompatible with ungrouped reader") {
+    intercept[InvalidRecordException] {
+      Schema.checkCompatibility(PtThreeLevelListEnc.schema, PtUngroupedList.schema)
     }
   }
 
   test("checkCompatibility: 3-level array writer incompatible with 3-level list reader") {
     intercept[InvalidRecordException] {
-      Schema.checkCompatibility(threeLevelArraySchema, threeLevelListSchema)
+      Schema.checkCompatibility(PtThreeLevelArrayEnc.schema, PtThreeLevelListEnc.schema)
+    }
+  }
+
+  test("checkCompatibility: 3-level array writer incompatible with 3-level list reader") {
+    intercept[InvalidRecordException] {
+      Schema.checkCompatibility(PtThreeLevelArrayEnc.schema, PtUngroupedList.schema)
     }
   }
 
   test("checkCompatibility: ungrouped writer incompatible with 3-level list reader") {
     intercept[InvalidRecordException] {
-      Schema.checkCompatibility(ungroupedSchema, threeLevelListSchema)
+      Schema.checkCompatibility(PtUngroupedList.schema, PtThreeLevelListEnc.schema)
     }
   }
 
   test("checkCompatibility: ungrouped writer incompatible with 3-level array reader") {
     intercept[InvalidRecordException] {
-      Schema.checkCompatibility(ungroupedSchema, threeLevelArraySchema)
+      Schema.checkCompatibility(PtUngroupedList.schema, PtThreeLevelArrayEnc.schema)
     }
   }
 
   test("checkCompatibility: primitive schemas are compatible") {
-    Schema.checkCompatibility(primitiveSchema, primitiveSchema)
+    Schema.checkCompatibility(PtUngroupedList.schema, PtUngroupedList.schema)
   }
 
-  test("checkCompatibility: reader with 3 level list field not in writer is not compatible") {
-    val e = intercept[InvalidRecordException] {
-      Schema.checkCompatibility(schemaNoListFields, threeLevelListSchema)
-    }
-    assert(e.getMessage.contains("is not present in written file schema"))
+  test("checkCompatibility: reader with 3 level list field not in writer is compatible") {
+    Schema.checkCompatibility(schemaNoListFields, PtThreeLevelListEnc.schema)
   }
 
-  test("checkCompatibility: reader with 3 level array field not in writer is not compatible") {
-    val e = intercept[InvalidRecordException] {
-      Schema.checkCompatibility(schemaNoListFields, threeLevelArraySchema)
-    }
-    assert(e.getMessage.contains("is not present in written file schema"))
+  test("checkCompatibility: reader with 3 level array field not in writer is compatible") {
+    Schema.checkCompatibility(schemaNoListFields, PtThreeLevelArrayEnc.schema)
   }
 
-  test("checkCompatibility: reader with 3 level optional list field not in writer is compatible") {
-    Schema.checkCompatibility(schemaNoListFields, threeLevelOptionalListSchema)
+  test("checkCompatibility: reader with ungrouped list field not in writer is compatible") {
+    Schema.checkCompatibility(schemaNoListFields, PtUngroupedList.schema)
   }
 
-  test("checkCompatibility: reader with 3 level optional array field not in writer is compatible") {
-    Schema.checkCompatibility(schemaNoListFields, threeLevelOptionalArraySchema)
-  }
-
-  test("checkCompatibility: reader with map field not in writer is not compatible") {
-    val e = intercept[InvalidRecordException] {
-      Schema.checkCompatibility(schemaNoListFields, mapSchema)
-    }
-    assert(e.getMessage.contains("is not present in written file schema"))
-  }
-
-  test("checkCompatibility: reader with ungrouped list field not in writer is not compatible") {
-    val e = intercept[InvalidRecordException] {
-      Schema.checkCompatibility(schemaNoListFields, ungroupedSchema)
-    }
-    assert(e.getMessage.contains("is not present in written file schema"))
+  test("checkCompatibility: reader with map field not in writer is compatible") {
+    Schema.checkCompatibility(
+      schemaNoListFields,
+      MessageTypeParser.parseMessageType(
+        """message Record {
+        |  required group my_map (MAP) {
+        |    repeated group key_value {
+        |      required binary key (STRING);
+        |      optional int32 value;
+        |    }
+        |  }
+        |}""".stripMargin
+      )
+    )
   }
 
   test("checkCompatibility: reader with optional field not in writer is compatible") {

--- a/parquet/src/test/scala/magnolify/parquet/SchemaSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/SchemaSuite.scala
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2026 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package magnolify.parquet
+
+import magnolify.test.MagnolifySuite
+import org.apache.parquet.io.InvalidRecordException
+import org.apache.parquet.schema.MessageTypeParser
+
+class SchemaSuite extends MagnolifySuite {
+
+  private val schemaNoListFields = MessageTypeParser.parseMessageType(
+    """message Record {
+      |  required int32 i1;
+      |  required group nestedGroup {
+      |    required int32 i2;
+      |  }
+      |}""".stripMargin
+  )
+
+  private val threeLevelListSchema = MessageTypeParser.parseMessageType(
+    """message Record {
+      |  required group nestedGroup {
+      |    required group listField (LIST) {
+      |      repeated group list {
+      |        required int32 element (INTEGER(32,true));
+      |      }
+      |    }
+      |  }
+      |}""".stripMargin
+  )
+
+  private val threeLevelArraySchema = MessageTypeParser.parseMessageType(
+    """message Record {
+      |  required group nestedGroup {
+      |    required group listField (LIST) {
+      |      repeated group array {
+      |        required int32 element (INTEGER(32,true));
+      |      }
+      |    }
+      |  }
+      |}""".stripMargin
+  )
+
+  private val ungroupedSchema = MessageTypeParser.parseMessageType(
+    """message Record {
+      |  required group nestedGroup {
+      |    repeated int32 listField (INTEGER(32,true));
+      |  }
+      |}""".stripMargin
+  )
+
+  private val primitiveSchema = MessageTypeParser.parseMessageType(
+    """message Record {
+      |  required int32 listField (INTEGER(32,true));
+      |}""".stripMargin
+  )
+
+  private val mapSchema = MessageTypeParser.parseMessageType(
+    """message Record {
+      |  required group my_map (MAP) {
+      |    repeated group key_value {
+      |      required binary key (STRING);
+      |      optional int32 value;
+      |    }
+      |  }
+      |}""".stripMargin
+  )
+
+  test("checkCompatibility: 3-level list writer compatible with 3-level list reader") {
+    Schema.checkCompatibility(threeLevelListSchema, threeLevelListSchema)
+  }
+
+  test("checkCompatibility: 3-level array writer compatible with 3-level array reader") {
+    Schema.checkCompatibility(threeLevelArraySchema, threeLevelArraySchema)
+  }
+
+  test("checkCompatibility: 3-level list writer incompatible with 3-level array reader") {
+    intercept[InvalidRecordException] {
+      Schema.checkCompatibility(threeLevelListSchema, threeLevelArraySchema)
+    }
+  }
+
+  test("checkCompatibility: 3-level array writer incompatible with 3-level list reader") {
+    intercept[InvalidRecordException] {
+      Schema.checkCompatibility(threeLevelArraySchema, threeLevelListSchema)
+    }
+  }
+
+  test("checkCompatibility: ungrouped writer incompatible with 3-level list reader") {
+    intercept[InvalidRecordException] {
+      Schema.checkCompatibility(ungroupedSchema, threeLevelListSchema)
+    }
+  }
+
+  test("checkCompatibility: ungrouped writer incompatible with 3-level array reader") {
+    intercept[InvalidRecordException] {
+      Schema.checkCompatibility(ungroupedSchema, threeLevelArraySchema)
+    }
+  }
+
+  test("checkCompatibility: primitive schemas are compatible") {
+    Schema.checkCompatibility(primitiveSchema, primitiveSchema)
+  }
+
+  test("checkCompatibility: reader with 3 level list field not in writer is not compatible") {
+    val e = intercept[InvalidRecordException] {
+      Schema.checkCompatibility(schemaNoListFields, threeLevelListSchema)
+    }
+    assert(e.getMessage.contains("is not present in written file schema"))
+  }
+
+  test("checkCompatibility: reader with 3 level array field not in writer is not compatible") {
+    val e = intercept[InvalidRecordException] {
+      Schema.checkCompatibility(schemaNoListFields, threeLevelArraySchema)
+    }
+    assert(e.getMessage.contains("is not present in written file schema"))
+  }
+
+  test("checkCompatibility: reader with map field not in writer is not compatible") {
+    val e = intercept[InvalidRecordException] {
+      Schema.checkCompatibility(schemaNoListFields, mapSchema)
+    }
+    assert(e.getMessage.contains("is not present in written file schema"))
+  }
+
+  test("checkCompatibility: reader with ungrouped list field not in writer is not compatible") {
+    val e = intercept[InvalidRecordException] {
+      Schema.checkCompatibility(schemaNoListFields, ungroupedSchema)
+    }
+    assert(e.getMessage.contains("is not present in written file schema"))
+  }
+
+  test("checkCompatibility: reader with optional field not in writer is compatible") {
+    val writer = MessageTypeParser.parseMessageType(
+      """message Record {
+        |  required int32 a (INTEGER(32,true));
+        |}""".stripMargin
+    )
+    val reader = MessageTypeParser.parseMessageType(
+      """message Record {
+        |  required int32 a (INTEGER(32,true));
+        |  optional int32 b (INTEGER(32,true));
+        |}""".stripMargin
+    )
+    Schema.checkCompatibility(writer, reader)
+  }
+
+  test("checkCompatibility: reader with required field not in writer fails") {
+    val writer = MessageTypeParser.parseMessageType(
+      """message Record {
+        |  required int32 a (INTEGER(32,true));
+        |}""".stripMargin
+    )
+    val reader = MessageTypeParser.parseMessageType(
+      """message Record {
+        |  required int32 a (INTEGER(32,true));
+        |  required int32 b (INTEGER(32,true));
+        |}""".stripMargin
+    )
+    val e = intercept[InvalidRecordException] {
+      Schema.checkCompatibility(writer, reader)
+    }
+    assert(e.getMessage.contains("not present"))
+  }
+}


### PR DESCRIPTION
Adds new failure cases to Schema#checkCompatibility:

- When reader and writer [list encoding types](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists) mismatch (`list` vs `array`)
- When reader requests a required list field that is not present in writer schema



