### PR TITLE
Add Hadoop config option to auto-derive Parquet list encoding from writer schema

### DIFF
--- a/docs/parquet.md
+++ b/docs/parquet.md
@@ -117,6 +117,35 @@ case class RecordWithList(listField: List[String])
 ParquetType[RecordWithList].schema
 ```
 
+### Auto-detecting list encodings
+
+As of Magnolify 0.9.5, passing in the Hadoop configuration option `parquet.type.read.auto-detect-list-encoding: true` at read time will instruct `ParquetType` to automatically infer list encoding from the writer schema,
+obviating the need to specify an encoding manually.
+
+```diff
+val pt = ParquetType[RecordWithList](
+-  new MagnolifyParquetProperties {
+-    override def writeArrayEncoding: ArrayEncoding = ArrayEncoding.ThreeLevelList
+-  }
+)
+
+val reader = pt
+  .readBuilder(...)
++ .withConf(ParquetConfiguration.of("parquet.type.read.auto-detect-list-encoding" -> true)
+  .build()
+```
+
+You can also set this property in a `core-site.xml` file in `src/main/resources/` to be automatically applied to every read in your project:
+
+```xml
+<configuration>
+  <property>
+    <name>parquet.type.read.auto-detect-list-encoding</name>
+    <value>true</value>
+  </property>
+</configuration>
+```
+
 ### AvroCompat import
 
 AvroCompat is a now-deprecated import used to enable the old list format:

--- a/parquet/src/main/scala/magnolify/parquet/ParquetType.scala
+++ b/parquet/src/main/scala/magnolify/parquet/ParquetType.scala
@@ -34,6 +34,7 @@ import org.apache.parquet.schema.MessageType
 import org.slf4j.LoggerFactory
 
 import scala.annotation.nowarn
+import scala.util.{Failure, Success, Try}
 
 sealed trait ParquetArray
 
@@ -92,6 +93,7 @@ sealed trait ParquetType[T] extends Serializable {
   def writeBuilder(file: OutputFile): WriteBuilder[T] = new WriteBuilder(file, writeSupport)
 
   private[parquet] def properties: MagnolifyParquetProperties
+  private[parquet] def updateProperties(newProps: MagnolifyParquetProperties): ParquetType[T]
 
   private[parquet] def write(c: RecordConsumer, v: T): Unit = ()
   private[parquet] def newConverter(): TypeConverter[T] = null
@@ -167,6 +169,9 @@ object ParquetType {
 
         override private[parquet] def properties: MagnolifyParquetProperties =
           propertiesWithAvroImportCompat
+        override private[parquet] def updateProperties(
+          newProps: MagnolifyParquetProperties
+        ): ParquetType[T] = ParquetType[T](cm, newProps)(f, pa)
         override def write(c: RecordConsumer, v: T): Unit =
           r.write(c, v)(cm, propertiesWithAvroImportCompat)
         override private[parquet] def newConverter(): TypeConverter[T] =
@@ -178,6 +183,8 @@ object ParquetType {
 
   val ReadTypeKey = "parquet.type.read.type"
   val WriteTypeKey = "parquet.type.write.type"
+
+  val AutoDetectListEncoding = "parquet.type.read.auto-detect-list-encoding"
 
   class ReadBuilder[T](file: InputFile, val readSupport: ReadSupport[T])
       extends ParquetReader.Builder[T](file) {
@@ -205,9 +212,34 @@ object ParquetType {
       }
 
       val writeSchema = context.getFileSchema
-      val readSchema = Schema.message(parquetType.schema)
 
-      Schema.checkCompatibility(writeSchema, readSchema)
+      val readSchema = {
+        val typeclassSchema = Schema.message(parquetType.schema)
+
+        Try(Schema.checkCompatibility(writeSchema, typeclassSchema)) match {
+          case Success(_) => typeclassSchema
+          // Try to auto-infer list encoding if configuration option is set
+          case Failure(_)
+              if context.getParquetConfiguration.getBoolean(AutoDetectListEncoding, false) =>
+            Schema.detectArrayEncoding(writeSchema).foreach { encoding =>
+              val currentProps = parquetType.properties
+              if (encoding != currentProps.writeArrayEncoding) {
+                this.parquetType = parquetType.updateProperties(new MagnolifyParquetProperties {
+                  override def writeArrayEncoding: ArrayEncoding = encoding
+
+                  override def writeAvroSchemaToMetadata: Boolean =
+                    currentProps.writeAvroSchemaToMetadata
+                })
+              }
+            }
+
+            val schemaWithListInference = Schema.message(parquetType.schema)
+            Schema.checkCompatibility(writeSchema, schemaWithListInference)
+            schemaWithListInference
+          case Failure(e) => throw e
+        }
+      }
+
       new hadoop.ReadSupport.ReadContext(readSchema)
     }
 

--- a/parquet/src/main/scala/magnolify/parquet/Schema.scala
+++ b/parquet/src/main/scala/magnolify/parquet/Schema.scala
@@ -95,6 +95,46 @@ private object Schema {
     builder.named(schema.getName)
   }
 
+  def detectArrayEncoding(schema: Type): Option[ArrayEncoding] = {
+    val encodings = scala.collection.mutable.Set.empty[ArrayEncoding]
+
+    def visit(t: Type): Unit = t match {
+      case g: GroupType if g.getLogicalTypeAnnotation == LogicalTypeAnnotation.listType() =>
+        g.getFields.asScala.headOption match {
+          case Some(child) if child.getName == "list" =>
+            encodings += ArrayEncoding.ThreeLevelList
+          case Some(child) if child.getName == "array" =>
+            encodings += ArrayEncoding.ThreeLevelArray
+          case Some(_) =>
+            throw new InvalidRecordException(
+              s"Schema contained unsupported list encoding ```$t```;" +
+                s" child element of LIST annotation must be one of: [list, array]`"
+            )
+          case None =>
+        }
+        g.getFields.asScala.foreach(visit)
+      case g: GroupType =>
+        g.getFields.asScala.foreach(visit)
+      case t: PrimitiveType if t.getRepetition == Repetition.REPEATED =>
+        encodings += ArrayEncoding.Ungrouped
+      case _ =>
+    }
+
+    schema match {
+      case g: GroupType => g.getFields.asScala.foreach(visit)
+      case _            =>
+    }
+
+    if (encodings.size > 1) {
+      throw new InvalidRecordException(
+        s"Multiple list encodings detected in writer schema: ${encodings.mkString(", ")}. " +
+          "Cannot auto-detect list encoding."
+      )
+    }
+
+    encodings.headOption
+  }
+
   def checkCompatibility(writer: Type, reader: Type): Unit = {
     def listFields(gt: GroupType) =
       s"[${gt.getFields.asScala.map(f => s"${f.getName}: ${f.getRepetition}").mkString(",")}]"

--- a/parquet/src/main/scala/magnolify/parquet/Schema.scala
+++ b/parquet/src/main/scala/magnolify/parquet/Schema.scala
@@ -122,21 +122,17 @@ private object Schema {
             val wf = wg.getType(rf.getName)
             checkCompatibility(wf, rf)
           } else {
-            (
-              rf.getLogicalTypeAnnotation != LogicalTypeAnnotation.listType(),
-              rf.getRepetition
-            ) match {
-              case (true, Repetition.REQUIRED) =>
-                throw new InvalidRecordException(
-                  s"Requested field `${rf.getName}: ${rf.getRepetition}` is not present in written file schema. " +
-                    s"Available fields are: ${listFields(wg)}"
-                )
-              case (true, Repetition.OPTIONAL) =>
+            rf.getRepetition match {
+              case Repetition.OPTIONAL =>
                 logger.warn(
                   s"Requested field `${rf.getName}: ${rf.getRepetition}` is not present in written file schema " +
                     s"and will be evaluated as `Option.empty`. Available fields are: ${listFields(wg)}"
                 )
               case _ =>
+                throw new InvalidRecordException(
+                  s"Requested field `${rf.getName}: ${rf.getRepetition}` is not present in written file schema. " +
+                    s"Available fields are: ${listFields(wg)}"
+                )
             }
           }
         }

--- a/parquet/src/test/scala/magnolify/parquet/ListCompatibilitySuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/ListCompatibilitySuite.scala
@@ -23,12 +23,13 @@ import org.apache.parquet.conf.{HadoopParquetConfiguration, ParquetConfiguration
 import org.apache.parquet.hadoop.ParquetWriter
 import org.apache.parquet.hadoop.api.WriteSupport
 import org.apache.parquet.hadoop.api.WriteSupport.WriteContext
-import org.apache.parquet.io.{LocalInputFile, LocalOutputFile}
+import org.apache.parquet.io.{InvalidRecordException, LocalInputFile, LocalOutputFile}
 import org.apache.parquet.io.api.RecordConsumer
 import org.apache.parquet.schema.{MessageType, MessageTypeParser}
 
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
+import scala.util.{Failure, Success, Try}
 
 case class RecordWithListPrimitive(listField: List[Int])
 
@@ -46,6 +47,10 @@ class ListCompatibilitySuite extends MagnolifySuite {
     (1 to 10).map(i => RecordWithListNested((0 until i).map(Element).toList))
 
   test("1-level list encoding with primitive list type") {
+    implicit val typeclass = ParquetType[RecordWithListPrimitive](new MagnolifyParquetProperties {
+      override def writeArrayEncoding: ArrayEncoding = Ungrouped
+    })
+
     val schema = s"""
      |message RecordWith1LevelListPrimitive {
      |  repeated int32 listField (INTEGER(32,true));
@@ -64,10 +69,14 @@ class ListCompatibilitySuite extends MagnolifySuite {
 
         rc.endMessage()
       }
-    )(typeclass = ParquetType[RecordWithListPrimitive])
+    )
   }
 
   test("2-level list encoding with primitive list type") {
+    implicit val typeclass = ParquetType[RecordWithListNested](new MagnolifyParquetProperties {
+      override def writeArrayEncoding: ArrayEncoding = ThreeLevelArray
+    })
+
     val schema = s"""
                     |message RecordWith2LevelListNested {
                     |  required group $ListField (LIST) {
@@ -104,13 +113,11 @@ class ListCompatibilitySuite extends MagnolifySuite {
 
         rc.endMessage()
       }
-    )(typeclass = ParquetType[RecordWithListNested](new MagnolifyParquetProperties {
-      override def writeArrayEncoding: ArrayEncoding = ThreeLevelArray
-    }))
+    )
   }
 
   test("3-Level list encoding with primitive list type") {
-    val typeClass = ParquetType[RecordWithListPrimitive](new MagnolifyParquetProperties {
+    implicit val typeClass = ParquetType[RecordWithListPrimitive](new MagnolifyParquetProperties {
       override def writeArrayEncoding: ArrayEncoding = ThreeLevelList
     })
 
@@ -154,11 +161,108 @@ class ListCompatibilitySuite extends MagnolifySuite {
 
         rc.endMessage()
       }
-    )(typeClass)
+    )
+  }
+
+  test("3-Level writer schema should fail to be read by 2-level reader schema") {
+    val typeClassList = ParquetType[RecordWithListPrimitive](new MagnolifyParquetProperties {
+      override def writeArrayEncoding: ArrayEncoding = ThreeLevelList
+    })
+
+    val typeClassArray = ParquetType[RecordWithListPrimitive](new MagnolifyParquetProperties {
+      override def writeArrayEncoding: ArrayEncoding = ThreeLevelArray
+    })
+
+    Try {
+      roundtripParquet[RecordWithListPrimitive](
+        writeSchema = typeClassList.schema,
+        records = recordsWithListPrimitive,
+        writeFn = { case (record, rc) =>
+          rc.startMessage()
+
+          rc.startField(ListField, 0)
+          rc.startGroup()
+
+          /** Reference: [[org.apache.parquet.avro.AvroWriteSupport#ThreeLevelListWriter]] */
+          rc.startField("list", 0)
+          record.listField.foreach { elem =>
+            rc.startGroup()
+
+            rc.startField("element", 0)
+            rc.addInteger(elem)
+            rc.endField("element", 0)
+
+            rc.endGroup()
+          }
+
+          rc.endField("list", 0)
+          rc.endGroup()
+          rc.endField(ListField, 0)
+
+          rc.endMessage()
+        }
+      )(typeClassList, typeClassArray)
+    } match {
+      case Failure(_: InvalidRecordException) => // success
+      case Failure(e)                         =>
+        fail(
+          s"Expected mismatched list encoding types to throw InvalidRecordException, but caught error $e"
+        )
+      case Success(_) =>
+        fail(s"Expected mismatched list encoding types to throw InvalidRecordException")
+    }
+  }
+
+  test("2-Level writer schema should fail to be read by 3-level reader schema") {
+    val typeClassList = ParquetType[RecordWithListNested](new MagnolifyParquetProperties {
+      override def writeArrayEncoding: ArrayEncoding = ThreeLevelList
+    })
+
+    val typeClassArray = ParquetType[RecordWithListNested](new MagnolifyParquetProperties {
+      override def writeArrayEncoding: ArrayEncoding = ThreeLevelArray
+    })
+
+    Try {
+      roundtripParquet[RecordWithListNested](
+        writeSchema = typeClassArray.schema,
+        records = recordsWithListNested,
+        writeFn = { case (record, rc) =>
+          rc.startMessage()
+
+          rc.startField(ListField, 0)
+          rc.startGroup()
+
+          rc.startField("array", 0)
+          record.listField.foreach { elem =>
+            rc.startGroup()
+
+            rc.startField("i", 0)
+            rc.addInteger(elem.i)
+            rc.endField("i", 0)
+
+            rc.endGroup()
+          }
+          rc.endField("array", 0)
+
+          rc.endGroup()
+          rc.endField(ListField, 0)
+
+          rc.endMessage()
+        }
+      )(typeClassArray, typeClassList)
+    } match {
+      case Failure(_: InvalidRecordException) => // success
+      case Failure(e)                         =>
+        fail(
+          s"Expected mismatched list encoding types to throw InvalidRecordException, but caught error $e"
+        )
+      case Success(_) =>
+        fail(s"Expected mismatched list encoding types to throw InvalidRecordException")
+    }
   }
 
   test("3-Level list encoding with nested list type") {
-    val typeClass = ParquetType[RecordWithListNested](new MagnolifyParquetProperties {
+    implicit val typeClass = ParquetType[RecordWithListNested](new MagnolifyParquetProperties {
       override def writeArrayEncoding: ArrayEncoding = ThreeLevelList
     })
 
@@ -209,7 +313,7 @@ class ListCompatibilitySuite extends MagnolifySuite {
 
         rc.endMessage()
       }
-    )(typeClass)
+    )
   }
 
   class LocalWriteBuilder[T](file: LocalOutputFile, writeSupport: WriteSupport[T])
@@ -222,7 +326,7 @@ class ListCompatibilitySuite extends MagnolifySuite {
     writeSchema: MessageType,
     records: Seq[T],
     writeFn: (T, RecordConsumer) => Unit
-  )(typeclass: ParquetType[T]): Unit = {
+  )(implicit writerTypeclass: ParquetType[T], readerTypeclass: ParquetType[T]): Unit = {
     // Write files manually using provided writer fn
     val manuallyWrittenRecords =
       Files.createTempFile(s"parquet-list-compat-manual-${writeSchema.getName}", ".parquet").toFile
@@ -265,7 +369,7 @@ class ListCompatibilitySuite extends MagnolifySuite {
       magnolifyWrittenRecords.delete() // creating a Path creates the file
       magnolifyWrittenRecords.deleteOnExit()
 
-      val writer = typeclass
+      val writer = writerTypeclass
         .writeBuilder(new LocalOutputFile(magnolifyWrittenRecords.toPath))
         .build()
 
@@ -275,7 +379,7 @@ class ListCompatibilitySuite extends MagnolifySuite {
 
     // Read using typeclass
     val readManuallyWrittenRecords = {
-      val reader = typeclass
+      val reader = readerTypeclass
         .readBuilder(new LocalInputFile(manuallyWrittenRecords.toPath))
         .build()
 
@@ -285,7 +389,7 @@ class ListCompatibilitySuite extends MagnolifySuite {
     }
 
     val readMagnolifyWrittenRecords = {
-      val reader = typeclass
+      val reader = readerTypeclass
         .readBuilder(new LocalInputFile(magnolifyWrittenRecords.toPath))
         .build()
 

--- a/parquet/src/test/scala/magnolify/parquet/ListCompatibilitySuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/ListCompatibilitySuite.scala
@@ -261,6 +261,90 @@ class ListCompatibilitySuite extends MagnolifySuite {
     }
   }
 
+  private val autoDetectConf = {
+    val conf = new Configuration()
+    conf.setBoolean(ParquetType.AutoDetectListEncoding, true)
+    conf
+  }
+
+  test("3-Level writer schema auto-detected by 2-level reader schema") {
+    val typeClassList = ParquetType[RecordWithListPrimitive](new MagnolifyParquetProperties {
+      override def writeArrayEncoding: ArrayEncoding = ThreeLevelList
+    })
+
+    val typeClassArray = ParquetType[RecordWithListPrimitive](new MagnolifyParquetProperties {
+      override def writeArrayEncoding: ArrayEncoding = ThreeLevelArray
+    })
+
+    roundtripParquet[RecordWithListPrimitive](
+      writeSchema = typeClassList.schema,
+      records = recordsWithListPrimitive,
+      writeFn = { case (record, rc) =>
+        rc.startMessage()
+
+        rc.startField(ListField, 0)
+        rc.startGroup()
+
+        rc.startField("list", 0)
+        record.listField.foreach { elem =>
+          rc.startGroup()
+
+          rc.startField("element", 0)
+          rc.addInteger(elem)
+          rc.endField("element", 0)
+
+          rc.endGroup()
+        }
+
+        rc.endField("list", 0)
+        rc.endGroup()
+        rc.endField(ListField, 0)
+
+        rc.endMessage()
+      },
+      readerConf = autoDetectConf
+    )(typeClassList, typeClassArray)
+  }
+
+  test("2-Level writer schema auto-detected by 3-level reader schema") {
+    val typeClassList = ParquetType[RecordWithListNested](new MagnolifyParquetProperties {
+      override def writeArrayEncoding: ArrayEncoding = ThreeLevelList
+    })
+
+    val typeClassArray = ParquetType[RecordWithListNested](new MagnolifyParquetProperties {
+      override def writeArrayEncoding: ArrayEncoding = ThreeLevelArray
+    })
+
+    roundtripParquet[RecordWithListNested](
+      writeSchema = typeClassArray.schema,
+      records = recordsWithListNested,
+      writeFn = { case (record, rc) =>
+        rc.startMessage()
+
+        rc.startField(ListField, 0)
+        rc.startGroup()
+
+        rc.startField("array", 0)
+        record.listField.foreach { elem =>
+          rc.startGroup()
+
+          rc.startField("i", 0)
+          rc.addInteger(elem.i)
+          rc.endField("i", 0)
+
+          rc.endGroup()
+        }
+        rc.endField("array", 0)
+
+        rc.endGroup()
+        rc.endField(ListField, 0)
+
+        rc.endMessage()
+      },
+      readerConf = autoDetectConf
+    )(typeClassArray, typeClassList)
+  }
+
   test("3-Level list encoding with nested list type") {
     implicit val typeClass = ParquetType[RecordWithListNested](new MagnolifyParquetProperties {
       override def writeArrayEncoding: ArrayEncoding = ThreeLevelList
@@ -325,7 +409,8 @@ class ListCompatibilitySuite extends MagnolifySuite {
   private def roundtripParquet[T](
     writeSchema: MessageType,
     records: Seq[T],
-    writeFn: (T, RecordConsumer) => Unit
+    writeFn: (T, RecordConsumer) => Unit,
+    readerConf: Configuration = new Configuration()
   )(implicit writerTypeclass: ParquetType[T], readerTypeclass: ParquetType[T]): Unit = {
     // Write files manually using provided writer fn
     val manuallyWrittenRecords =
@@ -381,6 +466,7 @@ class ListCompatibilitySuite extends MagnolifySuite {
     val readManuallyWrittenRecords = {
       val reader = readerTypeclass
         .readBuilder(new LocalInputFile(manuallyWrittenRecords.toPath))
+        .withConf(readerConf)
         .build()
 
       val records = (1 to 10).map(_ => reader.read())
@@ -391,6 +477,7 @@ class ListCompatibilitySuite extends MagnolifySuite {
     val readMagnolifyWrittenRecords = {
       val reader = readerTypeclass
         .readBuilder(new LocalInputFile(magnolifyWrittenRecords.toPath))
+        .withConf(readerConf)
         .build()
 
       val records = (1 to 10).map(_ => reader.read())

--- a/parquet/src/test/scala/magnolify/parquet/SchemaEvolutionSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/SchemaEvolutionSuite.scala
@@ -22,6 +22,7 @@ import magnolify.test._
 import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
 import org.apache.avro.{JsonProperties, Schema => AvroSchema}
 import org.apache.hadoop.conf.Configuration
+import org.apache.parquet.io.InvalidRecordException
 import org.apache.parquet.avro.{
   AvroParquetReader,
   AvroParquetWriter,
@@ -390,7 +391,10 @@ class SchemaEvolutionSuite extends MagnolifySuite {
   }
 
   test("Scala V1 => Scala V2") {
-    assertEquals(readScala[User2](scalaBytes1), scala1as2)
+    // V2 adds aliases (REPEATED) which is not present in V1
+    intercept[InvalidRecordException] {
+      readScala[User2](scalaBytes1)
+    }
   }
 
   test("Scala V2 => Scala V1") {
@@ -411,7 +415,10 @@ class SchemaEvolutionSuite extends MagnolifySuite {
 
   test("Scala Compat V1 => Scala Compat V2") {
     import magnolify.parquet.ParquetArray.AvroCompat._
-    assertEquals(readScala[User2](scalaCompatBytes1), scala1as2)
+    // In AvroCompat mode, aliases is a REQUIRED LIST group — not a valid schema evolution addition
+    intercept[InvalidRecordException] {
+      readScala[User2](scalaCompatBytes1)
+    }
   }
 
   test("Scala Compat V2 => Scala Compat V1") {
@@ -433,7 +440,10 @@ class SchemaEvolutionSuite extends MagnolifySuite {
 
   test("Avro V1 => Scala V2") {
     import magnolify.parquet.ParquetArray.AvroCompat._
-    assertEquals(readScala[User2](avroBytes1), scala1as2)
+    // In AvroCompat mode, aliases is a REQUIRED LIST group — not a valid schema evolution addition
+    intercept[InvalidRecordException] {
+      readScala[User2](avroBytes1)
+    }
   }
 
   test("Avro V2 => Scala V1") {

--- a/parquet/src/test/scala/magnolify/parquet/SchemaSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/SchemaSuite.scala
@@ -43,10 +43,34 @@ class SchemaSuite extends MagnolifySuite {
       |}""".stripMargin
   )
 
+  private val threeLevelOptionalListSchema = MessageTypeParser.parseMessageType(
+    """message Record {
+      |  required group nestedGroup {
+      |    optional group listField (LIST) {
+      |      repeated group list {
+      |        required int32 element (INTEGER(32,true));
+      |      }
+      |    }
+      |  }
+      |}""".stripMargin
+  )
+
   private val threeLevelArraySchema = MessageTypeParser.parseMessageType(
     """message Record {
       |  required group nestedGroup {
       |    required group listField (LIST) {
+      |      repeated group array {
+      |        required int32 element (INTEGER(32,true));
+      |      }
+      |    }
+      |  }
+      |}""".stripMargin
+  )
+
+  private val threeLevelOptionalArraySchema = MessageTypeParser.parseMessageType(
+    """message Record {
+      |  required group nestedGroup {
+      |    optional group listField (LIST) {
       |      repeated group array {
       |        required int32 element (INTEGER(32,true));
       |      }
@@ -128,6 +152,14 @@ class SchemaSuite extends MagnolifySuite {
       Schema.checkCompatibility(schemaNoListFields, threeLevelArraySchema)
     }
     assert(e.getMessage.contains("is not present in written file schema"))
+  }
+
+  test("checkCompatibility: reader with 3 level optional list field not in writer is compatible") {
+    Schema.checkCompatibility(schemaNoListFields, threeLevelOptionalListSchema)
+  }
+
+  test("checkCompatibility: reader with 3 level optional array field not in writer is compatible") {
+    Schema.checkCompatibility(schemaNoListFields, threeLevelOptionalArraySchema)
   }
 
   test("checkCompatibility: reader with map field not in writer is not compatible") {

--- a/parquet/src/test/scala/magnolify/parquet/SchemaSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/SchemaSuite.scala
@@ -191,6 +191,91 @@ class SchemaSuite extends MagnolifySuite {
     Schema.checkCompatibility(writer, reader)
   }
 
+  // detectArrayEncoding tests
+
+  test("detectArrayEncoding: schema with no list fields returns None") {
+    assertEquals(Schema.detectArrayEncoding(schemaNoListFields), None)
+  }
+
+  test("detectArrayEncoding: primitive-only schema returns None") {
+    assertEquals(Schema.detectArrayEncoding(primitiveSchema), None)
+  }
+
+  test("detectArrayEncoding: map schema returns None") {
+    assertEquals(Schema.detectArrayEncoding(mapSchema), None)
+  }
+
+  test("detectArrayEncoding: 3-level list schema returns ThreeLevelList") {
+    assertEquals(
+      Schema.detectArrayEncoding(threeLevelListSchema),
+      Some(ArrayEncoding.ThreeLevelList)
+    )
+  }
+
+  test("detectArrayEncoding: optional 3-level list schema returns ThreeLevelList") {
+    assertEquals(
+      Schema.detectArrayEncoding(threeLevelOptionalListSchema),
+      Some(ArrayEncoding.ThreeLevelList)
+    )
+  }
+
+  test("detectArrayEncoding: 3-level array schema returns ThreeLevelArray") {
+    assertEquals(
+      Schema.detectArrayEncoding(threeLevelArraySchema),
+      Some(ArrayEncoding.ThreeLevelArray)
+    )
+  }
+
+  test("detectArrayEncoding: optional 3-level array schema returns ThreeLevelArray") {
+    assertEquals(
+      Schema.detectArrayEncoding(threeLevelOptionalArraySchema),
+      Some(ArrayEncoding.ThreeLevelArray)
+    )
+  }
+
+  test("detectArrayEncoding: ungrouped schema returns Ungrouped") {
+    assertEquals(Schema.detectArrayEncoding(ungroupedSchema), Some(ArrayEncoding.Ungrouped))
+  }
+
+  test("detectArrayEncoding: mixed list encodings throws") {
+    val mixedSchema = MessageTypeParser.parseMessageType(
+      """message Record {
+        |  required group nestedGroup {
+        |    required group listA (LIST) {
+        |      repeated group list {
+        |        required int32 element (INTEGER(32,true));
+        |      }
+        |    }
+        |    required group listB (LIST) {
+        |      repeated group array {
+        |        required int32 element (INTEGER(32,true));
+        |      }
+        |    }
+        |  }
+        |}""".stripMargin
+    )
+    val e = intercept[InvalidRecordException] {
+      Schema.detectArrayEncoding(mixedSchema)
+    }
+    assert(e.getMessage.contains("Multiple list encodings"))
+  }
+
+  test("detectArrayEncoding: unsupported list inner group name throws") {
+    val unsupportedSchema = MessageTypeParser.parseMessageType(
+      """message Record {
+        |  required group listField (LIST) {
+        |    repeated group foobar {
+        |      required int32 element (INTEGER(32,true));
+        |    }
+        |  }
+        |}""".stripMargin
+    )
+    val e = intercept[InvalidRecordException] {
+      Schema.detectArrayEncoding(unsupportedSchema)
+    }
+    assert(e.getMessage.contains("unsupported list encoding"))
+  }
+
   test("checkCompatibility: reader with required field not in writer fails") {
     val writer = MessageTypeParser.parseMessageType(
       """message Record {

--- a/parquet/src/test/scala/magnolify/parquet/SchemaSuite.scala
+++ b/parquet/src/test/scala/magnolify/parquet/SchemaSuite.scala
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2026 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package magnolify.parquet
+
+import magnolify.test.MagnolifySuite
+import org.apache.parquet.io.InvalidRecordException
+import org.apache.parquet.schema.MessageTypeParser
+
+class SchemaSuite extends MagnolifySuite {
+
+  private val schemaNoListFields = MessageTypeParser.parseMessageType(
+    """message Record {
+      |  required int32 i1;
+      |  required group nestedGroup {
+      |    required int32 i2;
+      |  }
+      |}""".stripMargin
+  )
+
+  private val threeLevelListSchema = MessageTypeParser.parseMessageType(
+    """message Record {
+      |  required group nestedGroup {
+      |    required group listField (LIST) {
+      |      repeated group list {
+      |        required int32 element (INTEGER(32,true));
+      |      }
+      |    }
+      |  }
+      |}""".stripMargin
+  )
+
+  private val threeLevelArraySchema = MessageTypeParser.parseMessageType(
+    """message Record {
+      |  required group nestedGroup {
+      |    required group listField (LIST) {
+      |      repeated group array {
+      |        required int32 element (INTEGER(32,true));
+      |      }
+      |    }
+      |  }
+      |}""".stripMargin
+  )
+
+  private val ungroupedSchema = MessageTypeParser.parseMessageType(
+    """message Record {
+      |  required group nestedGroup {
+      |    repeated int32 listField (INTEGER(32,true));
+      |  }
+      |}""".stripMargin
+  )
+
+  private val primitiveSchema = MessageTypeParser.parseMessageType(
+    """message Record {
+      |  required int32 listField (INTEGER(32,true));
+      |}""".stripMargin
+  )
+
+  private val mapSchema = MessageTypeParser.parseMessageType(
+    """message Record {
+      |  required group my_map (MAP) {
+      |    repeated group key_value {
+      |      required binary key (STRING);
+      |      optional int32 value;
+      |    }
+      |  }
+      |}""".stripMargin
+  )
+
+  test("checkCompatibility: 3-level list writer compatible with 3-level list reader") {
+    Schema.checkCompatibility(threeLevelListSchema, threeLevelListSchema)
+  }
+
+  test("checkCompatibility: 3-level array writer compatible with 3-level array reader") {
+    Schema.checkCompatibility(threeLevelArraySchema, threeLevelArraySchema)
+  }
+
+  test("checkCompatibility: 3-level list writer incompatible with 3-level array reader") {
+    intercept[InvalidRecordException] {
+      Schema.checkCompatibility(threeLevelListSchema, threeLevelArraySchema)
+    }
+  }
+
+  test("checkCompatibility: 3-level array writer incompatible with 3-level list reader") {
+    intercept[InvalidRecordException] {
+      Schema.checkCompatibility(threeLevelArraySchema, threeLevelListSchema)
+    }
+  }
+
+  test("checkCompatibility: ungrouped writer incompatible with 3-level list reader") {
+    intercept[InvalidRecordException] {
+      Schema.checkCompatibility(ungroupedSchema, threeLevelListSchema)
+    }
+  }
+
+  test("checkCompatibility: ungrouped writer incompatible with 3-level array reader") {
+    intercept[InvalidRecordException] {
+      Schema.checkCompatibility(ungroupedSchema, threeLevelArraySchema)
+    }
+  }
+
+  test("checkCompatibility: primitive schemas are compatible") {
+    Schema.checkCompatibility(primitiveSchema, primitiveSchema)
+  }
+
+  test("checkCompatibility: reader with 3 level list field not in writer is not compatible") {
+    val e = intercept[InvalidRecordException] {
+      Schema.checkCompatibility(schemaNoListFields, threeLevelListSchema)
+    }
+    assert(e.getMessage.contains("is not present in written file schema"))
+  }
+
+  test("checkCompatibility: reader with 3 level array field not in writer is not compatible") {
+    val e = intercept[InvalidRecordException] {
+      Schema.checkCompatibility(schemaNoListFields, threeLevelArraySchema)
+    }
+    assert(e.getMessage.contains("is not present in written file schema"))
+  }
+
+  test("checkCompatibility: reader with map field not in writer is not compatible") {
+    val e = intercept[InvalidRecordException] {
+      Schema.checkCompatibility(schemaNoListFields, mapSchema)
+    }
+    assert(e.getMessage.contains("is not present in written file schema"))
+  }
+
+  test("checkCompatibility: reader with ungrouped list field not in writer is not compatible") {
+    val e = intercept[InvalidRecordException] {
+      Schema.checkCompatibility(schemaNoListFields, ungroupedSchema)
+    }
+    assert(e.getMessage.contains("is not present in written file schema"))
+  }
+
+  test("checkCompatibility: reader with optional field not in writer is compatible") {
+    val writer = MessageTypeParser.parseMessageType(
+      """message Record {
+        |  required int32 a (INTEGER(32,true));
+        |}""".stripMargin
+    )
+    val reader = MessageTypeParser.parseMessageType(
+      """message Record {
+        |  required int32 a (INTEGER(32,true));
+        |  optional int32 b (INTEGER(32,true));
+        |}""".stripMargin
+    )
+    Schema.checkCompatibility(writer, reader)
+  }
+
+  test("checkCompatibility: reader with required field not in writer fails") {
+    val writer = MessageTypeParser.parseMessageType(
+      """message Record {
+        |  required int32 a (INTEGER(32,true));
+        |}""".stripMargin
+    )
+    val reader = MessageTypeParser.parseMessageType(
+      """message Record {
+        |  required int32 a (INTEGER(32,true));
+        |  required int32 b (INTEGER(32,true));
+        |}""".stripMargin
+    )
+    val e = intercept[InvalidRecordException] {
+      Schema.checkCompatibility(writer, reader)
+    }
+    assert(e.getMessage.contains("not present"))
+  }
+}


### PR DESCRIPTION
(branched off https://github.com/spotify/magnolify/pull/1340; once that's merged I'll update the base ref)

Adds a hadoop configuration flag `parquet.type.read.auto-detect-list-encoding` that will instruct ParquetType to auto-detect list encoding based off writer schema.

todo: update benchmarks to check added ms cost per file