### PR TITLE
(magnolify-beam) RowType#from should look up field values by name, not index

### DIFF
--- a/beam/src/main/scala/magnolify/beam/RowType.scala
+++ b/beam/src/main/scala/magnolify/beam/RowType.scala
@@ -171,7 +171,9 @@ object RowField {
             .build()
 
         override def from(v: Row)(cm: CaseMapper): T =
-          caseClass.construct(p => p.typeclass.fromAny(v.getValue[Any](p.index))(cm))
+          caseClass.construct { p =>
+            p.typeclass.fromAny(v.getValue[Any](cm.map(p.label)))(cm)
+          }
 
         override def to(v: T)(cm: CaseMapper): Row = {
           val values = caseClass.parameters.map { p =>

--- a/beam/src/main/scala/magnolify/beam/RowType.scala
+++ b/beam/src/main/scala/magnolify/beam/RowType.scala
@@ -161,6 +161,8 @@ object RowField {
       }
     } else {
       new Record[T] {
+        @transient @volatile private var cachedFieldIndices: (ju.UUID, Array[Int]) = _
+
         override def fieldType(cm: CaseMapper): FieldType = FieldType.row(schema(cm))
 
         override protected def buildSchema(cm: CaseMapper): Schema =
@@ -170,10 +172,20 @@ object RowField {
             }
             .build()
 
-        override def from(v: Row)(cm: CaseMapper): T =
+        override def from(v: Row)(cm: CaseMapper): T = {
+          val cached = cachedFieldIndices
+          val indices =
+            if (cached != null && cached._1 == cm.uuid) cached._2
+            else {
+              val arr =
+                caseClass.parameters.map(p => v.getSchema.indexOf(cm.map(p.label))).toArray
+              cachedFieldIndices = (cm.uuid, arr)
+              arr
+            }
           caseClass.construct { p =>
-            p.typeclass.fromAny(v.getValue[Any](cm.map(p.label)))(cm)
+            p.typeclass.fromAny(v.getValue[Any](indices(p.index)))(cm)
           }
+        }
 
         override def to(v: T)(cm: CaseMapper): Row = {
           val values = caseClass.parameters.map { p =>

--- a/beam/src/test/scala/magnolify/beam/RowTypeSuite.scala
+++ b/beam/src/test/scala/magnolify/beam/RowTypeSuite.scala
@@ -166,7 +166,7 @@ class RowTypeSuite extends MagnolifySuite {
 
     val row = Row
       .withSchema(reorderedSchema)
-      .addValues("foo", 3, true)
+      .addValues("foo", Int.box(3), Boolean.box(true))
       .build()
 
     assertEquals(rt.from(row), Required(b = true, i = 3, s = "foo"))
@@ -200,12 +200,12 @@ class RowTypeSuite extends MagnolifySuite {
 
     val innerRow = Row
       .withSchema(innerSchema)
-      .addValues("inner", 1, false)
+      .addValues("inner", Int.box(1), Boolean.box(false))
       .build()
 
     val row = Row
       .withSchema(outerSchema)
-      .addValues(innerRow, "outer", List[Row]().asJava, true, null, 2)
+      .addValues(innerRow, "outer", List[Row]().asJava, Boolean.box(true), null, Int.box(2))
       .build()
 
     val result = rt.from(row)

--- a/beam/src/test/scala/magnolify/beam/RowTypeSuite.scala
+++ b/beam/src/test/scala/magnolify/beam/RowTypeSuite.scala
@@ -27,6 +27,7 @@ import magnolify.test.ADT
 import magnolify.test.MagnolifySuite
 import magnolify.test.Simple.*
 import org.apache.beam.sdk.schemas.Schema
+import org.apache.beam.sdk.values.Row
 import org.joda.time as joda
 import org.scalacheck.{Arbitrary, Gen, Prop}
 
@@ -149,6 +150,71 @@ class RowTypeSuite extends MagnolifySuite {
   {
     import magnolify.beam.logical.sql.*
     test[Sql]
+  }
+
+  test("RowType#from handles Row when writer and reader schema fields are in a different order") {
+    val rt = RowType[Required]
+
+    // Required case class field order: b (BOOLEAN), i (INT32), s (STRING)
+    // Build a Row with fields in a different order: s, i, b
+    val reorderedSchema = Schema
+      .builder()
+      .addField("s", Schema.FieldType.STRING)
+      .addField("i", Schema.FieldType.INT32)
+      .addField("b", Schema.FieldType.BOOLEAN)
+      .build()
+
+    val row = Row
+      .withSchema(reorderedSchema)
+      .addValues("foo", 3, true)
+      .build()
+
+    assertEquals(rt.from(row), Required(b = true, i = 3, s = "foo"))
+  }
+
+  test(
+    "RowType#from handles Row when nested writer and reader schema fields are in a different order"
+  ) {
+    val rt = RowType[Nested]
+
+    // Build inner Required schema in reverse order: s, i, b
+    val innerSchema = Schema
+      .builder()
+      .addField("s", Schema.FieldType.STRING)
+      .addField("i", Schema.FieldType.INT32)
+      .addField("b", Schema.FieldType.BOOLEAN)
+      .build()
+
+    // Build outer Nested schema in a different order than the case class
+    // Case class order: b, i, s, r, o, l
+    // Reordered:        r, s, l, b, o, i
+    val outerSchema = Schema
+      .builder()
+      .addField("r", Schema.FieldType.row(innerSchema))
+      .addField("s", Schema.FieldType.STRING)
+      .addField("l", Schema.FieldType.iterable(Schema.FieldType.row(innerSchema)))
+      .addField("b", Schema.FieldType.BOOLEAN)
+      .addField("o", Schema.FieldType.row(innerSchema).withNullable(true))
+      .addField("i", Schema.FieldType.INT32)
+      .build()
+
+    val innerRow = Row
+      .withSchema(innerSchema)
+      .addValues("inner", 1, false)
+      .build()
+
+    val row = Row
+      .withSchema(outerSchema)
+      .addValues(innerRow, "outer", List[Row]().asJava, true, null, 2)
+      .build()
+
+    val result = rt.from(row)
+    assertEquals(result.b, true)
+    assertEquals(result.i, 2)
+    assertEquals(result.s, "outer")
+    assertEquals(result.r, Required(b = false, i = 1, s = "inner"))
+    assertEquals(result.o, None)
+    assertEquals(result.l, List.empty[Required])
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -705,6 +705,7 @@ lazy val jmh: Project = project
   .enablePlugins(JmhPlugin)
   .dependsOn(
     avro % Test,
+    beam % Test,
     bigquery % Test,
     bigtable % Test,
     cats % Test,
@@ -726,6 +727,7 @@ lazy val jmh: Project = project
     Jmh / compile := (Jmh / compile).dependsOn(Test / compile).value,
     Jmh / run := (Jmh / run).dependsOn(Jmh / compile).evaluated,
     libraryDependencies ++= Seq(
+      "org.apache.beam" % "beam-sdks-java-core" % beamVersion % Test,
       "com.google.api.grpc" % "proto-google-cloud-bigtable-v2" % bigtableVersion % Test,
       "com.google.apis" % "google-api-services-bigquery" % bigqueryVersion % Test,
       "com.google.cloud.datastore" % "datastore-v1-proto-client" % datastoreVersion % Test,

--- a/jmh/src/test/scala/magnolify/jmh/MagnolifyBench.scala
+++ b/jmh/src/test/scala/magnolify/jmh/MagnolifyBench.scala
@@ -16,6 +16,8 @@
 
 package magnolify.jmh
 
+import magnolify.parquet.ArrayEncoding.ThreeLevelArray
+
 import java.util.concurrent.TimeUnit
 import magnolify.scalacheck.auto._
 import magnolify.test.Simple._
@@ -107,6 +109,19 @@ class TableRowBench {
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
+class RowBench {
+  import magnolify.beam._
+  import org.apache.beam.sdk.values.Row
+  import MagnolifyBench._
+  private val rowType = RowType[Nested]
+  private val row = rowType(nested)
+  @Benchmark def rowTo: Row = rowType(nested)
+  @Benchmark def rowFrom: Nested = rowType(row)
+}
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
 class BigtableBench {
   import com.google.bigtable.v2.Mutation
   import com.google.protobuf.ByteString
@@ -153,7 +168,7 @@ class ProtobufBench {
 class ExampleBench {
   import magnolify.tensorflow._
   import magnolify.tensorflow.unsafe._
-  import org.tensorflow.proto.example.Example
+  import org.tensorflow.proto.Example
   import MagnolifyBench._
   private val exampleType = ExampleType[ExampleNested]
   private val exampleNested = implicitly[Arbitrary[ExampleNested]].arbitrary(prms, seed).get
@@ -188,7 +203,6 @@ object ParquetStates {
   import MagnolifyBench._
   import magnolify.avro._
   import magnolify.parquet._
-  import magnolify.parquet.ParquetArray.AvroCompat._
   import org.apache.avro.generic.{GenericData, GenericRecord}
   import org.apache.hadoop.conf.Configuration
   import org.apache.parquet.conf.PlainParquetConfiguration
@@ -269,7 +283,9 @@ object ParquetStates {
   }
 
   // R/W support for Group <-> Case Class Conversion (magnolify-parquet)
-  private val parquetType = ParquetType[Nested]
+  private val parquetType = ParquetType[Nested](new MagnolifyParquetProperties {
+    override def writeArrayEncoding: ArrayEncoding = ThreeLevelArray
+  })
   class ParquetCaseClassReadState
       extends ParquetStates.ReadState[Nested](
         parquetType.schema,


### PR DESCRIPTION
IcebergIO with beam `Row` isn't like Avro in the sense that you pass it a reader schema ahead of time and it will decode Iceberg records into `Rows` with where the field index is always guaranteed to match your Magnolify#RowType schema. (From what I can tell it will always match the order of the Iceberg table schema itself; passing the `keep` config option with rows in the different orders doesn't affect the returned Row schema at all). Therefore we should look up fields by name, not index.

~Won't undraft until I run the benchmarks, it will probably be a bit slower :( this is potentially something we could look into fixing on the Beam side~

Update 7/14: with benchmarks, this does slow down RowType#rowFrom quite a lot.

Baseline (`main` branch):
```
[info] Benchmark         Mode  Cnt      Score     Error  Units
[info] RowBench.rowFrom  avgt   10    984.269 ±   7.242  ns/op
[info] RowBench.rowTo    avgt   10  26021.345 ± 141.150  ns/op
```

This PR branch:
```
[info] Benchmark         Mode  Cnt      Score     Error  Units
[info] RowBench.rowFrom  avgt   10   1620.904 ±   1.539  ns/op
[info] RowBench.rowTo    avgt   10  25987.984 ± 930.496  ns/op
```

Update 7/15: pushed https://github.com/spotify/magnolify/commit/248c272d5fd8cffa1fa282cfb25069a8705c7819 which caches field indices after encountering them in the first `from` invocation, which significantly improves RowType#from performance:

```
[info] Benchmark         Mode  Cnt     Score   Error  Units
[info] RowBench.rowFrom  avgt   10  1053.535 ± 9.473  ns/op
```

I think this is close enough to baseline that i'll undraft the PR.