### PR TITLE
docs: fix 4 typos in comments and messages

### DIFF
--- a/bigquery/src/main/scala/magnolify/bigquery/TimestampConverter.scala
+++ b/bigquery/src/main/scala/magnolify/bigquery/TimestampConverter.scala
@@ -65,7 +65,7 @@ private object TimestampConverter {
     .toFormatter()
 
   // TIMESTAMP
-  // https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#time_type
+  // https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp_type
 
   // civil_date_part YYYY-[M]M-[D]D
   private val civilDatePartFormatter = dateFormatter

--- a/neo4j/src/main/scala/magnolify/neo4j/ValueType.scala
+++ b/neo4j/src/main/scala/magnolify/neo4j/ValueType.scala
@@ -95,7 +95,7 @@ object ValueField {
     }
   }
 
-  @implicitNotFound("Cannot derive AvroField for sealed trait")
+  @implicitNotFound("Cannot derive ValueField for sealed trait")
   private sealed trait Dispatchable[T]
 
   def split[T: Dispatchable](sealedTrait: SealedTrait[Typeclass, T]): ValueField[T] = ???

--- a/parquet/src/main/scala/magnolify/parquet/Schema.scala
+++ b/parquet/src/main/scala/magnolify/parquet/Schema.scala
@@ -113,7 +113,7 @@ private object Schema {
       writer.isPrimitive != reader.isPrimitive
     ) {
       throw new InvalidRecordException(
-        s"Writer schema `$writer` incompatible with reader schema `$reader``"
+        s"Writer schema `$writer` incompatible with reader schema `$reader`"
       )
     }
 

--- a/parquet/src/main/scala/magnolify/parquet/logical/package.scala
+++ b/parquet/src/main/scala/magnolify/parquet/logical/package.scala
@@ -24,7 +24,7 @@ import org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit
 
 package object logical {
   import magnolify.shared.Time._
-  // TIME (millis i32, micros i64, nanos, i64), UTC true/false
+  // TIME (millis i32, micros i64, nanos i64), UTC true/false
   // TIMESTAMP (millis, micros, nanos), UTC true/false
 
   object millis extends TimeTypes {


### PR DESCRIPTION
## Summary

Fix 4 small typos/copy-paste errors:

- **neo4j/src/main/scala/magnolify/neo4j/ValueType.scala**: `@implicitNotFound("Cannot derive AvroField for sealed trait")` -> `... ValueField ...`. Copy-paste from the avro module; every other module names its own typeclass here (`ProtobufField`, `TableRowField`, `ExampleField`, `EntityField`, `BigtableField`), so the neo4j derivation currently reports the wrong type in the compile error.
- **parquet/src/main/scala/magnolify/parquet/Schema.scala**: stray double backtick in the `InvalidRecordException` message - `reader schema `$reader``" ` -> `reader schema `$reader`"`.
- **bigquery/src/main/scala/magnolify/bigquery/TimestampConverter.scala**: the doc link under the `// TIMESTAMP` heading pointed at `data-types#time_type`; changed to `data-types#timestamp_type`. (The `#time_type` link under the `// TIME` heading is correct and was left alone.)
- **parquet/src/main/scala/magnolify/parquet/logical/package.scala**: `// TIME (millis i32, micros i64, nanos, i64)` -> `nanos i64` (stray comma).

Please note one change touches a string literal: the `InvalidRecordException` message in `Schema.scala`. No test in the repo asserts on that text (grepped), and the change only removes a duplicated backtick, but flagging it so it gets a second look. Everything else is comments/annotations.

No functional changes and no identifiers renamed.